### PR TITLE
Resolving a UAF with cross hub migration

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -157,6 +157,8 @@ ENV/
 env.bak/
 venv.bak/
 
+.venv-*/
+
 # Spyder project settings
 .spyderproject
 .spyproject

--- a/src/patches/README.md
+++ b/src/patches/README.md
@@ -1,5 +1,19 @@
 # CPython patches for runloom
 
+Cross-hub fiber migration needs **both** patches below. They fix independent
+halves of the same root cause — free-threaded CPython ties a running frame to
+one OS thread in two separate ways — and either alone still corrupts:
+
+| half | patch | flag | what it decouples |
+|---|---|---|---|
+| **allocation** | `cpython313t-tstate-alloc-home.patch` | `Py_TSTATE_ALLOC_HOME` | which heap a migrated fiber allocates on |
+| **execution** | `cpython314t-tstate-exec-home.patch` | `Py_TSTATE_EXEC_HOME` | whether the compiler may cache *which OS thread we are* |
+
+`runloom.migration_available()` is True only with both; `runloom.migration_status()`
+reports which half is missing. With either absent, migration stays behind the
+`RUNLOOM_ALLOW_UNSAFE_MIGRATION` dev override and the scheduler falls back to the
+default non-migrating mode with a warning naming the gap.
+
 ## `cpython313t-tstate-alloc-home.patch` — per-tstate allocation home
 
 Optional CPython 3.13t feature (`-DPy_TSTATE_ALLOC_HOME`, **off by default**) that
@@ -31,27 +45,207 @@ proof (`tests/experiments/resume_rebuild/migration_crosshub_proof.py`) shows **5
 wake on a different hub than they parked on, zero crash** — real cross-hub migration
 of transparent stackful fibers.
 
+**Scope limit:** this patch moves the *heap*. It does nothing about the compiler
+caching *which OS thread is running* — see the exec-home patch below, which is
+required alongside it.
+
+## `cpython314t-tstate-exec-home.patch` — non-cacheable execution-context reads
+
+Optional CPython feature (`-DPy_TSTATE_EXEC_HOME`, **off by default**) that stops
+the optimizer from caching the two reads identifying the OS thread a frame runs
+on: `_PyThreadState_GET()` (via `pycore_pystate.h`, now routed through the
+out-of-line `_PyThreadState_GetCurrent()`, which gains `Py_NO_INLINE` so LTO can't
+undo it) and `_Py_ThreadId()` (via `object.h`, whose per-arch reads become
+volatile asm).
+
+**Why it's needed.** Both reads are pure expressions, so the compiler hoists them
+out of loops, CSEs repeats into one, and sinks them to function entry. That is
+sound under C's assumption that a live frame stays on one OS thread — an
+assumption a stackful fiber scheduler breaks by swapping C stacks. The result is
+a use-after-free with no incorrect C anywhere in the source:
+
+- a stale `_PyThreadState_GET()` drives another thread's exception state /
+  recursion limits / delayed-free queue, or one already freed by
+  `PyThreadState_Delete()` if the origin hub has exited;
+- a stale `_Py_ThreadId()` makes `_Py_IsOwnedByCurrentThread()` answer "yes" on a
+  thread that doesn't own the object, routing decrefs down the **non-atomic**
+  `ob_ref_local` path. Racing threads there lose or duplicate decrements; a
+  duplicated one frees an object still referenced elsewhere.
+
+**Not a Darwin problem.** The manifestation is platform-specific; the bug is not.
+Compiling a read of the thread-local twice around an opaque call that can migrate
+the fiber (clang `-O2`) — the second read is the one that must see the new thread:
+
+| target | what the compiler does to the second read |
+|---|---|
+| Darwin/AArch64 | caches the **address**: one `tlv_get_addr` per function, spilled to the stack frame and reused |
+| Linux/x86-64 | caches the **value**: `movq %fs:tss_tstate@TPOFF, %rbx` before the call, `movq %rbx, %rax` after — the second read is deleted |
+| Linux/AArch64 | same: `mrs x8, TPIDR_EL0; ldr x19, [x8]` before, `mov x0, x19` after |
+
+Identical under `-ftls-model=` `local-exec`, `initial-exec` and `global-dynamic`.
+The Linux form is arguably worse — no address is involved at all, so there is
+nothing to "resolve correctly"; the value simply predates the migration. It is a
+legal optimization: the slot's address never escapes, so LLVM concludes no other
+thread can write it — true only while a frame stays on one thread.
+
+`_Py_ThreadId()` is worse still, because its per-arch reads are plain
+(non-`volatile`) asm. On **all three** targets clang deletes *both* reads around
+the call and folds `tid_before == tid_after` to a compile-time `mov w0, #1` —
+"same thread", decided at compile time. Patched, each emits two real reads.
+
+*(Linux numbers here are cross-compiled codegen only; the runtime soak below was
+run on arm64 Darwin.)*
+
+**The crash, in situ.** In `_PyEval_EvalFrameDefault` (3.14.4t, `-O2`, clang 21,
+Darwin/arm64) the faulting sequence is:
+
+```
+ldr x9,  [sp, #0xf8]     ; cached &_Py_tss_tstate  <-- ORIGIN hub's slot
+ldr x20, [x9]            ; tstate
+ldr x9,  [x20, #0x350]   ; tstate->c_stack_soft_limit   <-- SIGSEGV, x20 == 0
+```
+
+The frame is on the *fiber's* stack, so it travels to whichever hub resumes the
+fiber and keeps reading the origin hub's slot. Caught in the act: the crashing
+thread's own `&_Py_tss_tstate` was `0x100cd84b8`, while the address cached in its
+eval frame was `0x100cd6ff8` — a **different** hub thread's slot, and that thread
+was parked idle in `cvwait`, so the slot held NULL. Had it instead been running
+another fiber, the read would have returned a valid-but-wrong tstate and corrupted
+state silently. The same fault reproduces as `_PyCriticalSection_BeginMutex`
+(offset `0xb0`) and `_PyErr_Occurred` (offset `0x70`) depending on which inlined
+`_PyThreadState_GET()` the optimizer happened to reuse.
+
+**Default build:** zero change — `_Py_TID_ASM` expands to plain `__asm__` and
+`_PyThreadState_GET()` keeps its inline thread-local read, both behind `#ifdef`.
+No ABI change. Enabled, it costs exactly the hoist/CSE the inline reads exist to
+enable.
+
+**Validation status: VALIDATED end-to-end** (3.14.4t, arm64, release `-O2`, with
+alloc-home applied). `benchmark/bench_migration.py` **before**: `--hubs 1` clean,
+`--hubs 2/4/8` SIGSEGV every run. **After**: `--hubs 1/2/4/8` all clean, 10/10 soak
+runs at 8 hubs × 64 fibers × 60 rounds × 32 allocs, with **77–80% of wakes landing
+on a different hub than the fiber parked on**. `mpmc_pergt_repro.py` and
+`migration_crosshub_proof.py` both pass; runloom's own suite is unchanged (223
+passed / 1 skipped, and the two residual failures — `test_mn_sim_bytes` late-parker,
+`test_monkey_leak` subprocess — reproduce identically on the *unpatched*
+interpreter, so they are pre-existing). **Not** run against the CPython test suite.
+
+alloc-home is genuinely required alongside exec-home: with `RUNLOOM_NO_ALLOC_HOME=1`
+(exec-home on, alloc-home off) `mpmc_pergt_repro.py` still crashed **3/8** runs vs
+**0/8** with both.
+
+### Which exec-home half fixes what
+
+exec-home has two halves, and they are *not* equally evidenced. Three interpreters,
+identical apart from the patch, running `exec_home_min.py --hubs 4`, 10 runs each:
+
+| build | halves present | result |
+|---|---|---|
+| `.venv-orig` | neither | **SIGSEGV 10/10** |
+| `.venv-halfa` | `_PyThreadState_GET()` only | clean 10/10 |
+| `.venv-mig` | both | clean 10/10 |
+
+**The crash is entirely attributable to the `_PyThreadState_GET()` half.** The
+`volatile` `_Py_ThreadId()` half contributes nothing to fixing it.
+
+That half is kept on different grounds. Its mechanism is concrete and readable in
+`refcount.h` — a stale thread id mis-answers `_Py_IsOwnedByCurrentThread()`, sending
+a refcount update down the **non-atomic** `ob_ref_local` path from a thread that does
+not own the object, which loses updates when the real owner does the same thing
+concurrently. But **no failure has been pinned on it**. A canary hammering
+main-thread-owned objects from migrating fibers came back clean on all three builds
+(its first version reported drift on all three, including the fixed one — a
+self-inflicted false positive from `for o in SHARED` leaving `o` bound). A lost
+refcount update is silent, so a clean run cannot distinguish "unnecessary" from "not
+yet observed". It is kept because it measured **free** and covers the failure class
+testing cannot rule out. Settling it properly needs ThreadSanitizer on `ob_ref_local`
+under migration; that has not been run.
+
+**Cost.** Measured against the **alloc-home-only** build — i.e. this is the marginal
+cost of adding exec-home to the original patch, not the cost of migration support
+as a whole. Three interpreters built identically apart from the patch;
+interpreter-bound microbenchmark, 2M iterations, min of 5, 3.14.4t arm64:
+
+| | alloc-home only | + exec-home | Δ |
+|---|---|---|---|
+| dict alloc churn | 0.152 s | 0.176 s | +16% |
+| function call | 0.042 s | 0.045 s | +7% |
+| list alloc churn | 0.112 s | 0.124 s | +11% |
+
+All of it is the `_PyThreadState_GET()` out-of-lining: the half-only build measures
+0.175 / 0.044 / 0.125 s, indistinguishable from both halves. The `volatile`
+`_Py_ThreadId()` is free. Anyone making migration cheaper should target the tstate
+lookup, not the thread id.
+
+> An earlier revision of this file quoted +38/+15/+52%. That was wrong: it compared
+> against a separately-built interpreter rather than a controlled baseline, so build
+> differences were being counted as patch cost. The table above compares three
+> interpreters built from the same source with the same configure line.
+
+**⚠ Do not build with `--with-lto` / `--enable-optimizations`.** exec-home works by
+making `_PyThreadState_GetCurrent()` a genuine cross-TU call that cannot be CSE'd;
+LTO can inline it back into its callers and silently reintroduce the bug.
+`Py_NO_INLINE` covers only the same-TU case.
+
+**⚠ Rebuild everything.** `_Py_ThreadId()` is inlined into `Py_INCREF`/`Py_DECREF`
+through the *public* `refcount.h`, so the fix only reaches code compiled against
+the patched headers. Every extension module in a migrating process must be rebuilt
+— a prebuilt wheel keeps its cacheable reads. `runloom_c.exec_home_available` can
+only speak for runloom's own extension.
+
+**Known gaps:** on MSVC the thread-id reads are intrinsics (`__readgsqword`,
+`__getReg`), not asm, and are left untouched — free-threaded MSVC isn't a migration
+target today. Two other thread-locals are in the same class but not covered because
+no fiber path reads them across a park: `pkgcontext` (`Python/import.c`) and
+mimalloc's `_mi_heap_default` (object allocation reaches the heap through the
+tstate — see alloc-home — not through it).
+
 ## Using it (production, behind flags)
 
 Migration is **off by default**. To enable it you need two things: build CPython with
-this patch, and set the flag.
+**both** patches, and set the flag.
 
-1. **Build CPython with the patch** (one-time):
+1. **Build CPython with both patches.** `tools/build_migration_cpython.sh` does the
+   whole thing — fetch, patch, configure, build, install, create a venv, build
+   runloom into it, and assert both halves report present:
    ```sh
-   cd cpython && patch -p1 < .../patches/cpython313t-tstate-alloc-home.patch
-   # turn the feature ON for this interpreter:
-   echo '#define Py_TSTATE_ALLOC_HOME 1' >> pyconfig.h    # or: ./configure CPPFLAGS=-DPy_TSTATE_ALLOC_HOME
+   tools/build_migration_cpython.sh          # PY_VER / PREFIX / VENV_DIR overridable
+   ```
+   By hand:
+   ```sh
+   cd cpython
+   patch -p1 -F3 < .../patches/cpython313t-tstate-alloc-home.patch   # 3.13-era context
+   patch -p1     < .../patches/cpython314t-tstate-exec-home.patch
+   ./configure --disable-gil CPPFLAGS="-DPy_TSTATE_ALLOC_HOME -DPy_TSTATE_EXEC_HOME"
+   # ALSO put both #defines in pyconfig.h -- CPPFLAGS covers only the CPython
+   # build, while extension modules include the INSTALLED pyconfig.h.  alloc-home
+   # adds a field to _PyThreadStateImpl, so a mismatch shifts struct offsets
+   # silently rather than failing to link.
+   printf '#define Py_TSTATE_ALLOC_HOME 1\n#define Py_TSTATE_EXEC_HOME 1\n' >> pyconfig.h
    make && make install
    ```
-   Then build runloom against that interpreter (`python setup.py build_ext --inplace`).
-   The same runloom source builds against **stock** CPython too — the borrow compiles
-   out to a no-op, so nothing about the default build changes.
+   The alloc-home patch predates 3.14 and needs `-F3` there; even with fuzz its
+   `_PyThreadStateImpl_AllocHome` accessor hunk is rejected, and must be pasted in
+   by hand after `} _PyThreadStateImpl;` in `pycore_tstate.h`. Check with
+   `grep -q _PyThreadStateImpl_AllocHome Include/internal/pycore_tstate.h` before
+   building — the bootstrap script fails loudly on this, by hand you get a silently
+   half-patched interpreter.
+
+   Then build runloom against that interpreter (`python setup.py build_ext --inplace`),
+   **and rebuild every other extension module you load** — `_Py_ThreadId()` inlines
+   into `Py_INCREF`/`Py_DECREF` via the public `refcount.h`, so a wheel built against
+   unpatched headers keeps the cacheable reads.
+
+   The same runloom source builds against **stock** CPython too — both features
+   compile out to no-ops, so nothing about the default build changes.
 
 2. **Opt in at runtime** (before the runtime starts — the flag is read once at init):
    ```python
    import runloom
-   if runloom.migration_available():        # True only on a patched interpreter
+   if runloom.migration_available():        # True only with BOTH patches
        runloom.enable_migration()           # or set RUNLOOM_MIGRATION=1 in the env
+   else:
+       print(runloom.migration_status())    # which half is missing
    runloom.run(n_hubs, main)
    ```
 
@@ -60,15 +254,18 @@ this patch, and set the flag.
 | flag / call | effect |
 |---|---|
 | `RUNLOOM_MIGRATION=1` | production master switch — enables cross-hub migration |
-| `runloom.migration_available()` | `True` iff built against the patch (safe to enable) |
-| `runloom.enable_migration()` | set the flag; **raises** on an unpatched build |
+| `runloom.migration_available()` | `True` iff built against **both** patches (safe to enable) |
+| `runloom.migration_status()` | `{"alloc_home":…, "exec_home":…, "available":…}` — which half is missing |
+| `runloom.enable_migration()` | set the flag; **raises** (naming the missing patch) on an under-patched build |
 | `runloom.migration_enabled()` | whether migration was requested for the next run |
-| `runloom_c.alloc_home_available` | the raw C-level capability bit (`0`/`1`) |
+| `runloom_c.alloc_home_available` | raw C-level capability bit for the allocation half (`0`/`1`) |
+| `runloom_c.exec_home_available` | raw C-level capability bit for the execution half (`0`/`1`) |
 | `RUNLOOM_NO_ALLOC_HOME=1` | disable the heap-borrow (A/B baseline; reproduces the crash) |
-| `RUNLOOM_ALLOW_UNSAFE_MIGRATION=1` | **dev/fuzz only** — force migration on *stock* CPython (can crash under churn) |
+| `RUNLOOM_ALLOW_UNSAFE_MIGRATION=1` | **dev/fuzz only** — force migration on an under-patched CPython (can crash / UAF under churn) |
 
-**Safety contract (validated):** on a build *without* the patch, `RUNLOOM_MIGRATION=1`
-prints a one-line warning and **falls back to the default non-migrating scheduler — no
-crash**, and `enable_migration()` raises rather than risk a segfault. The unsafe
-override exists only for fuzzing the unpatched path. `RUNLOOM_PER_G_TSTATE` and
-`RUNLOOM_STEAL_WOKEN` remain as internal aliases of `RUNLOOM_MIGRATION`.
+**Safety contract (validated):** on a build missing **either** patch,
+`RUNLOOM_MIGRATION=1` prints a warning naming the missing half and **falls back to
+the default non-migrating scheduler — no crash**, and `enable_migration()` raises
+rather than risk a segfault. The unsafe override exists only for fuzzing the
+under-patched path. `RUNLOOM_PER_G_TSTATE` and `RUNLOOM_STEAL_WOKEN` remain as
+internal aliases of `RUNLOOM_MIGRATION`.

--- a/src/patches/cpython314t-tstate-exec-home.patch
+++ b/src/patches/cpython314t-tstate-exec-home.patch
@@ -1,0 +1,205 @@
+# CPython 3.14t OPTIONAL feature patch: thread-state EXECUTION home
+#   build flag:  -DPy_TSTATE_EXEC_HOME      (OFF by default)
+#
+# WHAT: stops the compiler caching "which OS thread is this frame running on".
+# Two reads carry that identity and both are covered:
+#   _PyThreadState_GET()  -> out-of-line call  (pycore_pystate.h, pystate.c)
+#   _Py_ThreadId()        -> volatile asm      (object.h)
+#
+# WHY: compilers treat thread identity as loop-invariant and hoist/CSE it.  That
+# is sound for OS threads, whose stacks never move.  A stackful fiber parks on
+# one OS thread and resumes on another carrying its C frames, so those cached
+# values keep naming the ORIGIN thread.  Measured, clang -O2, reading twice
+# around an opaque call that may migrate the fiber:
+#
+#   Darwin/AArch64    caches the ADDRESS -- one tlv_get_addr per function,
+#                     spilled to the stack frame and reused.
+#   Linux x86-64      caches the VALUE -- second read deleted, pre-call value
+#   and AArch64       kept in a callee-saved register.  Same under
+#                     -ftls-model=local-exec / initial-exec / global-dynamic.
+#   _Py_ThreadId()    elided on ALL THREE: both reads deleted and
+#                     `tid_before == tid_after` folded to `mov w0, #1`.
+#
+# So in a migrated frame _PyThreadState_GET() resolves against the origin thread:
+# NULL if it has detached -> SIGSEGV (_Py_Dealloc -> _Py_RecursionLimit_GetMargin
+# at offset 0x350, _PyCriticalSection_BeginMutex 0xb0, _PyErr_Occurred 0x70), or
+# a valid-but-WRONG tstate if it is running -> silent corruption.
+#
+# This is the EXECUTION half of migration support; the ALLOCATION half is
+# cpython313t-tstate-alloc-home.patch.  They are independent and both are needed:
+# alloc-home alone still segfaults at H>=2 under migration.
+#
+# MEASURED (runloom, CPython 3.14.4t, arm64 Darwin, release -O2; three
+# interpreters built identically apart from the patch; repro
+# tests/experiments/resume_rebuild/exec_home_min.py at 4 hubs, 10 runs each):
+#
+#   alloc-home only                  SIGSEGV 10/10
+#   + _PyThreadState_GET() half      clean   10/10   <- the crash is THIS half
+#   + both halves                    clean   10/10
+#
+# COST, measured against the alloc-home-only build (i.e. the marginal cost of
+# THIS patch, not of migration support as a whole).  Interpreter-bound
+# microbenchmark, 2M iters, min of 5:
+#
+#                     alloc-home   +this patch
+#   dict alloc churn    0.152s       0.176s   (+16%)
+#   function call       0.042s       0.045s   (+7%)
+#   list alloc churn    0.112s       0.124s   (+11%)
+#
+# All of it is the _PyThreadState_GET() out-of-lining: the half-only build
+# measures 0.175/0.044/0.125, indistinguishable from both halves.  The volatile
+# _Py_ThreadId() half is free.
+#
+# NOT DEMONSTRATED: no failure has been pinned on the _Py_ThreadId() half -- the
+# SIGSEGV above is entirely the other one.  Its biased-refcount mechanism is read
+# off refcount.h, and a lost refcount update is silent, so a clean run cannot
+# distinguish "unnecessary" from "not yet observed".  Kept because it is free.
+# Settling it needs ThreadSanitizer on ob_ref_local under migration; not run.
+#
+# NOT RUN ON LINUX: the Linux codegen above is cross-compiled evidence only;
+# every runtime result here is arm64 Darwin.
+#
+# ZERO IMPACT BY DEFAULT: with the flag undefined every site macro-expands back
+# to stock.  No ABI change (unlike alloc-home, no struct field is added).
+#
+# CAVEATS
+#   * Do NOT build with --with-lto / --enable-optimizations: the fix depends on
+#     _PyThreadState_GetCurrent() staying a real cross-TU call, and LTO can fold
+#     it back.  Py_NO_INLINE covers only the same-TU case.
+#   * Do NOT annotate _PyThreadState_GetCurrent() pure/const -- it looks eligible
+#     and would silently re-license the folding this prevents.
+#   * APPLY BOTH HUNKS.  Py_TSTATE_EXEC_HOME is armed in pyconfig.h independently
+#     of whether the patch landed, so a partial build would advertise the feature
+#     while lacking it.  The object.h hunk defines _Py_TID_ASM in both arms as a
+#     compile-time witness; test for both (runloom does).  Check by hand with:
+#         grep _Py_TID_ASM Include/object.h
+#   * MSVC thread-id reads are intrinsics, not asm, and are left untouched.
+#   * Same class, not covered (not read by a fiber across a park in any path
+#     exercised so far): import.c's `pkgcontext`, mimalloc's _mi_heap_default.
+#
+# ENABLE: ./configure --disable-gil CPPFLAGS=-DPy_TSTATE_EXEC_HOME
+#         (also add the #define to pyconfig.h so extension modules agree)
+# APPLY:  from the CPython source root:  patch -p1 < this-file   (or git apply)
+# SCOPE:  Include/object.h, Include/internal/pycore_pystate.h, Python/pystate.c
+#
+--- a/Include/object.h
++++ b/Include/object.h
+@@ -182,6 +182,21 @@
+ #if defined(Py_GIL_DISABLED) && !defined(Py_LIMITED_API)
+ PyAPI_FUNC(uintptr_t) _Py_GetThreadLocal_Addr(void);
+ 
++/* Py_TSTATE_EXEC_HOME: volatile, so the thread-pointer read below cannot be
++   hoisted, CSE'd or deleted.  A stackful fiber (greenlet/runloom-style) can park
++   on one OS thread and resume on another carrying its C frames, so a cached tid
++   names the ORIGIN thread.  _Py_ThreadId() gates _Py_IsOwnedByCurrentThread(),
++   so a stale tid routes a refcount update down the non-atomic ob_ref_local path
++   from a thread that does not own the object -- losing updates when the true
++   owner does the same concurrently.  (Mechanism read off refcount.h; no failure
++   has been pinned on it.  Kept because it measures free and a lost refcount
++   update is silent.)  MSVC's intrinsic reads are not covered. */
++#ifdef Py_TSTATE_EXEC_HOME
++#  define _Py_TID_ASM __asm__ __volatile__
++#else
++#  define _Py_TID_ASM __asm__
++#endif
++
+ static inline uintptr_t
+ _Py_ThreadId(void)
+ {
+@@ -199,24 +214,24 @@
+ #elif defined(__MINGW32__) && defined(_M_ARM64)
+     tid = __getReg(18);
+ #elif defined(__i386__)
+-    __asm__("{movl %%gs:0, %0|mov %0, dword ptr gs:[0]}" : "=r" (tid));  // 32-bit always uses GS
++    _Py_TID_ASM("{movl %%gs:0, %0|mov %0, dword ptr gs:[0]}" : "=r" (tid));  // 32-bit always uses GS
+ #elif defined(__MACH__) && defined(__x86_64__)
+-    __asm__("{movq %%gs:0, %0|mov %0, qword ptr gs:[0]}" : "=r" (tid));  // x86_64 macOSX uses GS
+-#elif defined(__x86_64__)
+-    __asm__("{movq %%fs:0, %0|mov %0, qword ptr fs:[0]}" : "=r" (tid));  // x86_64 Linux, BSD uses FS
++    _Py_TID_ASM("{movq %%gs:0, %0|mov %0, qword ptr gs:[0]}" : "=r" (tid));  // x86_64 macOSX uses GS
++#elif defined(__x86_64__)
++    _Py_TID_ASM("{movq %%fs:0, %0|mov %0, qword ptr fs:[0]}" : "=r" (tid));  // x86_64 Linux, BSD uses FS
+ #elif defined(__arm__) && __ARM_ARCH >= 7
+-    __asm__ ("mrc p15, 0, %0, c13, c0, 3\nbic %0, %0, #3" : "=r" (tid));
++    _Py_TID_ASM ("mrc p15, 0, %0, c13, c0, 3\nbic %0, %0, #3" : "=r" (tid));
+ #elif defined(__aarch64__) && defined(__APPLE__)
+-    __asm__ ("mrs %0, tpidrro_el0" : "=r" (tid));
++    _Py_TID_ASM ("mrs %0, tpidrro_el0" : "=r" (tid));
+ #elif defined(__aarch64__)
+-    __asm__ ("mrs %0, tpidr_el0" : "=r" (tid));
++    _Py_TID_ASM ("mrs %0, tpidr_el0" : "=r" (tid));
+ #elif defined(__powerpc64__)
+     #if defined(__clang__) && _Py__has_builtin(__builtin_thread_pointer)
+     tid = (uintptr_t)__builtin_thread_pointer();
+     #else
+     // r13 is reserved for use as system thread ID by the Power 64-bit ABI.
+     register uintptr_t tp __asm__ ("r13");
+-    __asm__("" : "=r" (tp));
++    _Py_TID_ASM("" : "=r" (tp));
+     tid = tp;
+     #endif
+ #elif defined(__powerpc__)
+@@ -225,7 +240,7 @@
+     #else
+     // r2 is reserved for use as system thread ID by the Power 32-bit ABI.
+     register uintptr_t tp __asm__ ("r2");
+-    __asm__ ("" : "=r" (tp));
++    _Py_TID_ASM ("" : "=r" (tp));
+     tid = tp;
+     #endif
+ #elif defined(__s390__) && defined(__GNUC__)
+@@ -237,7 +252,7 @@
+     tid = (uintptr_t)__builtin_thread_pointer();
+     #else
+     // tp is Thread Pointer provided by the RISC-V ABI.
+-    __asm__ ("mv %0, tp" : "=r" (tid));
++    _Py_TID_ASM ("mv %0, tp" : "=r" (tid));
+     #endif
+ #else
+     // Fallback to a portable implementation if we do not have a faster
+--- a/Include/internal/pycore_pystate.h
++++ b/Include/internal/pycore_pystate.h
+@@ -114,9 +114,14 @@
+ static inline PyThreadState*
+ _PyThreadState_GET(void)
+ {
+-#if defined(HAVE_THREAD_LOCAL) && !defined(Py_BUILD_CORE_MODULE)
++#if defined(HAVE_THREAD_LOCAL) && !defined(Py_BUILD_CORE_MODULE) \
++    && !defined(Py_TSTATE_EXEC_HOME)
+     return _Py_tss_tstate;
+ #else
++    /* With Py_TSTATE_EXEC_HOME this is deliberately an out-of-line call:
++       the ADDRESS of the _Py_tss_tstate thread-local must be recomputed on the
++       OS thread that is running RIGHT NOW.  See the comment on
++       _PyThreadState_GetCurrent() in Python/pystate.c. */
+     return _PyThreadState_GetCurrent();
+ #endif
+ }
+--- a/Python/pystate.c
++++ b/Python/pystate.c
+@@ -109,7 +109,25 @@
+     if (tstate == current_fast_get()) { \
+         _Py_FatalErrorFormat(__func__, "tstate %p is still current", tstate); \
+     }
++
++/* Py_TSTATE_EXEC_HOME: out of line, and it must stay un-foldable.
++
++   Compilers treat "which thread am I" as loop-invariant and cache it across
++   calls -- clang -O2 caches the slot ADDRESS on Darwin/AArch64 and the loaded
++   VALUE on Linux x86-64/AArch64.  Sound for OS threads, whose stacks never move;
++   wrong for a stackful fiber that parks on one thread and resumes on another,
++   whose C frames travel with it.  Every inlined _PyThreadState_GET() in those
++   frames then resolves against the ORIGIN thread: NULL if it has since detached
++   (SIGSEGV in e.g. _Py_Dealloc -> _Py_RecursionLimit_GetMargin), or a
++   valid-but-WRONG tstate if it is running something else (silent corruption).
+ 
++   Three things keep this un-foldable and all are load-bearing: it is a real
++   cross-TU call, so do NOT build with LTO; it must NOT be annotated pure/const
++   (it looks eligible, and that would re-license exactly this folding);
++   Py_NO_INLINE covers callers inside this TU. */
++#ifdef Py_TSTATE_EXEC_HOME
++Py_NO_INLINE
++#endif
+ PyThreadState *
+ _PyThreadState_GetCurrent(void)
+ {

--- a/src/runloom/__init__.py
+++ b/src/runloom/__init__.py
@@ -154,10 +154,33 @@ if _autosize_env in ("1", "on", "true", "prescan"):
 # flag is read once at mn_init).
 def migration_available():
     """True iff this build can SAFELY migrate fibers across hubs -- i.e. it was
-    compiled against the alloc-home CPython patch (see src/patches/).  On stock
-    CPython this is False and migration is only reachable via the
-    RUNLOOM_ALLOW_UNSAFE_MIGRATION dev override (which can crash under churn)."""
-    return bool(getattr(_core, "alloc_home_available", 0))
+    compiled against BOTH optional CPython patches (see src/patches/):
+
+      alloc-home (Py_TSTATE_ALLOC_HOME) -- a migrated fiber allocates on the hub
+        now running it, so no per-fiber heap migrates OS threads.
+      exec-home  (Py_TSTATE_EXEC_HOME)  -- _PyThreadState_GET() and _Py_ThreadId()
+        stay non-cacheable, so a resumed fiber can't keep using the origin hub's
+        thread state or resolve biased-refcount ownership against a stale thread
+        id (a use-after-free).
+
+    Either patch alone is insufficient.  When this is False, migration is only
+    reachable via the RUNLOOM_ALLOW_UNSAFE_MIGRATION dev override (which can
+    crash under churn).  See migration_status() for which half is missing.
+
+    NOTE exec-home is a codegen property and _Py_ThreadId() inlines into
+    Py_INCREF/Py_DECREF via the public refcount.h, so this can only speak for
+    runloom's own extension.  A fully sound migrating process also needs every
+    OTHER extension module rebuilt against the patched interpreter."""
+    return bool(getattr(_core, "alloc_home_available", 0)) and \
+           bool(getattr(_core, "exec_home_available", 0))
+
+def migration_status():
+    """Which halves of the migration safety gate this build has, as a dict:
+    {"alloc_home": bool, "exec_home": bool, "available": bool}.  Useful for
+    diagnosing a migration_available() of False."""
+    alloc = bool(getattr(_core, "alloc_home_available", 0))
+    exech = bool(getattr(_core, "exec_home_available", 0))
+    return {"alloc_home": alloc, "exec_home": exech, "available": alloc and exech}
 
 def migration_enabled():
     """True iff cross-hub migration is REQUESTED for the next runtime start
@@ -178,12 +201,25 @@ def enable_migration(allow_unsafe=False):
     migration can then crash under churn at >1 hub -- dev/fuzzing only).
     Idempotent."""
     if not migration_available() and not allow_unsafe:
+        st = migration_status()
+        missing = ", ".join(
+            name for name, have in (
+                ("alloc-home (src/patches/cpython313t-tstate-alloc-home.patch)",
+                 st["alloc_home"]),
+                ("exec-home (src/patches/cpython314t-tstate-exec-home.patch)",
+                 st["exec_home"]),
+            ) if not have
+        )
         raise RuntimeError(
-            "runloom: cross-hub migration needs CPython built with the alloc-home "
-            "patch (src/patches/cpython313t-tstate-alloc-home.patch); without it a "
-            "per-g PyThreadState's heap migrates across hub threads and crashes "
-            "under churn. Rebuild against the patch, or pass allow_unsafe=True "
-            "for dev/fuzzing on stock CPython."
+            "runloom: cross-hub migration needs CPython built with BOTH optional "
+            f"patches; missing: {missing}. Without alloc-home a per-g "
+            "PyThreadState's heap migrates across hub threads and crashes under "
+            "churn; without exec-home the compiler caches the thread-identity "
+            "reads across a park/resume, so a migrated fiber uses the origin "
+            "hub's thread state and mis-resolves biased-refcount ownership "
+            "(use-after-free). Rebuild CPython against the patches (and rebuild "
+            "extension modules against it), or pass allow_unsafe=True for "
+            "dev/fuzzing."
         )
     _os.environ["RUNLOOM_MIGRATION"] = "1"
     if allow_unsafe and not migration_available():
@@ -227,7 +263,8 @@ __all__ = [
     "mn_init", "mn_fiber", "mn_run", "mn_fini", "mn_hub_count", "mn_hub_states",
     "hubs",
     # cross-hub migration (opt-in, needs the alloc-home CPython patch)
-    "migration_available", "migration_enabled", "enable_migration",
+    "migration_available", "migration_status", "migration_enabled",
+    "enable_migration",
     # low-level I/O primitives
     "TCPConn", "Coro", "G", "wait_fd", "WAIT_FD_CANCELLED",
     "tcp_recv", "tcp_send", "iouring_available",

--- a/src/runloom_c/io_uring.c
+++ b/src/runloom_c/io_uring.c
@@ -335,6 +335,16 @@ runloom_iouring_ssize_t runloom_iouring_ring_send(runloom_iouring_ring_t *r,
     errno = ENOSYS;
     return -1;
 }
+/* MUST report failure (-1), not 0: on success the submitted op would OWN dup_fd
+ * and close it from the ring drain.  There is no ring here, so claiming success
+ * would strand the caller's dup_fd with nobody to close it -- an fd leak per
+ * cancel.  -1 leaves ownership with the caller, which closes it. */
+int runloom_iouring_ring_submit_cancel_fd(runloom_iouring_ring_t *r, int dup_fd)
+{
+    (void)r; (void)dup_fd;
+    errno = ENOSYS;
+    return -1;
+}
 
 /* io_uring-as-loop backend stubs (Linux-only feature).  enabled()/ms_enabled()
  * return 0 so the hub idle path and the all-C echo never take the loop path on
@@ -342,6 +352,7 @@ runloom_iouring_ssize_t runloom_iouring_ring_send(runloom_iouring_ring_t *r,
  * mn_sched.c / module_io.c.inc reference them unconditionally (runtime-gated). */
 int runloom_iouring_loop_enabled(void)    { return 0; }
 int runloom_iouring_loop_ms_enabled(void) { return 0; }
+int runloom_iouring_loop_pump_always(void){ return 0; }
 int runloom_iouring_any_enabled(void)     { return 0; }
 int runloom_iouring_loop_hub_arm(runloom_iouring_ring_t *r, int epoll_fd)
 {

--- a/src/runloom_c/mn_sched.h
+++ b/src/runloom_c/mn_sched.h
@@ -74,9 +74,9 @@
  *   on a standby thread) was REMOVED (2026-06) because it migrated suspended
  *   fibers with none of the above in place, and was redundant with
  *   work-stealing anyway (idle hubs already drain a wedged hub's FRESH fibers
- *   safely).  Regression guard for the UNPATCHED case: the RUNLOOM_DIAG_MIGRATE
- *   detector in runloom_sched_pystate.c.inc fires if any snap carrying a live
- *   Python frame is loaded under a tstate other than the one it was saved on.
+ *   safely).  The snap-migration machinery it relied on (the cross-hub snap
+ *   re-root + the RUNLOOM_DIAG_MIGRATE tripwire) has since been removed too,
+ *   now that per-g-tstate is the only migration path.
  *
  *   Wake interrupts: when a hub steals work, it needs to inform other
  *   hubs that may be sleeping in epoll_wait.  Use eventfd / pipe

--- a/src/runloom_c/mn_sched.h
+++ b/src/runloom_c/mn_sched.h
@@ -29,33 +29,54 @@
  *   it.  pump() runs in any hub when its local queue is empty and
  *   wakes whichever hub's g was parked.
  *
- *   Goroutine pinning: a g is created on a hub and runs ONLY on that
- *   hub.  Greenlets / our coros have absolute stack pointers that
- *   tie them to a single OS thread.  Work-stealing here steals only
- *   READY ("fresh", snap.valid==0) fibers -- they have NEVER run, so
- *   there is no stack/tstate to migrate: the stealer runs them clean
- *   from the start on its OWN tstate, and if such a fiber later parks
- *   it parks AND resumes on that same hub.  No migration.
+ *   Goroutine placement.  There are now TWO modes; the default is the one
+ *   this header originally described, and migration is opt-in on top of it.
  *
- *   *** DO NOT add cross-OS-thread migration of a SUSPENDED fiber. ***
- *   It is UNSOUND in stock free-threaded CPython.  Once a fiber has run
- *   and parked (snap.valid==1) the eval loop's PyThreadState pointer is
- *   baked into the frozen coro stack (spilled to eval-frame slots, not a
- *   single rewritable register), and one _PyThreadState_GET() serves BOTH
- *   the allocator AND execution (PyErr/recursion/GC).  Resuming that frozen
- *   frame on a different hub drives the wrong tstate's datastack/heap ->
- *   corruption: an arm64 SIGSEGV that is benign-looking on x86-TSO, so it
- *   passes local x86 review and code reasoning and only dies on weak memory.
- *   This is why the old "handoff-rescue" pool (run a wedged hub's fibers on
- *   a standby thread) was REMOVED (2026-06): it migrated suspended fibers,
- *   and was redundant with work-stealing anyway (idle hubs already drain a
- *   wedged hub's FRESH fibers safely).  Full analysis + the only sound path
- *   (the opt-in CPython execution/alloc-home hook + per-g-tstate, gated
- *   behind RUNLOOM_ALLOW_UNSAFE_MIGRATION until the patch lands):
- *   docs/dev/HUB_MIGRATION_VERDICT.md and docs/dev/STEAL_WOKEN_CLEANUP.md.
- *   Regression guard: the RUNLOOM_DIAG_MIGRATE detector in
- *   runloom_sched_pystate.c.inc fires if any snap carrying a live Python
- *   frame is loaded under a tstate other than the one it was saved on.
+ *   DEFAULT (stock CPython, no flag).  A g is created on a hub and runs ONLY
+ *   on that hub.  Greenlets / our coros have absolute stack pointers that tie
+ *   them to a single OS thread.  Work-stealing steals only READY ("fresh",
+ *   snap.valid==0) fibers -- they have NEVER run, so there is no stack/tstate
+ *   to migrate: the stealer runs them clean from the start on its OWN tstate,
+ *   and if such a fiber later parks it parks AND resumes on that same hub.
+ *   A woken fiber goes to its origin hub's local FIFO, never the stealable
+ *   deque.  No migration of a suspended fiber, ever.
+ *
+ *   MIGRATION (opt-in: RUNLOOM_MIGRATION=1 / runloom.enable_migration()).
+ *   Each fiber carries its OWN PyThreadState, so a suspended fiber is no
+ *   longer bound to one hub: a woken fiber is pushed to the process-global
+ *   run-queue and resumed by whichever hub drains it (see the global-runq
+ *   block in mn_sched_runq.c.inc).  That is what lets an idle hub rescue the
+ *   woken work of a hub wedged in a blocking C call -- the failure the
+ *   default mode cannot recover from.  Fresh-fiber work-stealing is unchanged
+ *   and still runs alongside it.
+ *
+ *   Why migration needs a patched interpreter.  In STOCK free-threaded
+ *   CPython it is unsound, for two independent reasons, and either alone
+ *   still corrupts:
+ *     - ALLOCATION: one _PyThreadState_GET() serves both the allocator and
+ *       execution, so a migrated fiber allocates on the origin hub's heap
+ *       (mimalloc heap->thread_id mismatch -> _mi_page_retire corruption).
+ *       Fixed by Py_TSTATE_ALLOC_HOME.
+ *     - EXECUTION: the compiler may hoist/CSE the two reads identifying the
+ *       OS thread a frame runs on, so a resumed fiber keeps using the origin
+ *       hub's tstate (freed outright if that hub exited) and mis-resolves
+ *       _Py_IsOwnedByCurrentThread(), routing decrefs down the non-atomic
+ *       ob_ref_local path from the wrong thread -> use-after-free.  Fixed by
+ *       Py_TSTATE_EXEC_HOME.  An arm64 SIGSEGV that looks benign on x86-TSO,
+ *       so it survives local x86 review and only dies on weak memory.
+ *   Both patches, the build recipe, and the measured validation live in
+ *   src/patches/README.md.  runloom.migration_available() reports whether
+ *   this build has both; with both, migration enables with no override.
+ *   Missing either, a migration request is GATED OFF (warn + run the default
+ *   scheduler) unless RUNLOOM_ALLOW_UNSAFE_MIGRATION=1 -- dev/fuzzing only.
+ *
+ *   Historical note: the old "handoff-rescue" pool (run a wedged hub's fibers
+ *   on a standby thread) was REMOVED (2026-06) because it migrated suspended
+ *   fibers with none of the above in place, and was redundant with
+ *   work-stealing anyway (idle hubs already drain a wedged hub's FRESH fibers
+ *   safely).  Regression guard for the UNPATCHED case: the RUNLOOM_DIAG_MIGRATE
+ *   detector in runloom_sched_pystate.c.inc fires if any snap carrying a live
+ *   Python frame is loaded under a tstate other than the one it was saved on.
  *
  *   Wake interrupts: when a hub steals work, it needs to inform other
  *   hubs that may be sleeping in epoll_wait.  Use eventfd / pipe

--- a/src/runloom_c/mn_sched_hub_main.c.inc
+++ b/src/runloom_c/mn_sched_hub_main.c.inc
@@ -1376,27 +1376,17 @@ static RUNLOOM_THREAD_RET runloom_hub_main(void *arg)
                 continue;
             }
 
-            /* Steal-woken (or any non-per-g global-runq mode): a from_runq g
-             * arrived via a queue entry holding a queue ref, in wake_state
-             * QUEUED.  Claim it QUEUED->RUNNING (sole entry holder -> cannot
-             * lose).  Fresh / deque / local-FIFO / stolen gs are already
-             * RUNNING.  from_runq is only ever set under runloom_use_global_runq(),
-             * so this block is inert in the byte-unchanged default. */
-            int parked_offqueue = 0;
-            if (from_runq) {
-                int qexp = RUNLOOM_WS_QUEUED;
-                if (!__atomic_compare_exchange_n(&g->wake_state, &qexp,
-                                                 RUNLOOM_WS_RUNNING, 0,
-                                                 __ATOMIC_ACQ_REL,
-                                                 __ATOMIC_ACQUIRE)) {
-                    /* Not QUEUED: a queued g is parked-waiting, never done, so
-                     * this shouldn't happen.  Stay leak-safe: drop the queue ref
-                     * and skip. */
-                    runloom_g_decref(g);   /* queue ref */
-                    continue;
-                }
-                RUNLOOM_WS_NOTE(RUNLOOM_WS_QUEUED, RUNLOOM_WS_RUNNING);
-            }
+            /* Default (per-hub-tstate) scheduler resume + release.  The steal-
+             * woken snap-migration variant that used to share this branch (a
+             * QUEUED->RUNNING claim here, a RUNNING_WOKEN release below) has been
+             * removed: it was reachable only when runloom_use_global_runq() was
+             * true, but that returns per-g-tstate mode, which takes the branch
+             * ABOVE -- so it was dead in every mode (per-g uses its own tstate,
+             * not the snap).  The remaining `if (from_runq)` guards below are
+             * likewise inert here (from_runq is set only under global-runq mode);
+             * they are LEFT in place -- never firing -- rather than surgically
+             * excised from this CBMC-verified refcount-lifetime path
+             * (tools/verify/cbmc/sched_qref_cbmc.c). */
 
             if (g->snap.valid) {
                 runloom_pystate_load(&g->snap);
@@ -1540,9 +1530,8 @@ static RUNLOOM_THREAD_RET runloom_hub_main(void *arg)
             }
             runloom_hub_resume_end(h);
             self_queued = runloom_tls_self_queued;
-            parked_offqueue = runloom_tls_parked_offqueue;
             runloom_tls_self_queued = 0;
-            runloom_tls_parked_offqueue = 0;
+            runloom_tls_parked_offqueue = 0;   /* reset the park flag for next g */
             runloom_tls_current_g = NULL;
             h->sched.current = NULL;
 
@@ -1582,71 +1571,6 @@ static RUNLOOM_THREAD_RET runloom_hub_main(void *arg)
                  * which must be visible before mn_run observes pending == 0. */
                 runloom_mn_pending_complete(h);
                 runloom_pystate_snap(&hub_snap);
-            } else if (runloom_use_global_runq()) {
-                /* Steal-woken release via the wake-state machine -- a near-exact
-                 * mirror of the per-g-tstate release above; the difference is
-                 * only that the migrated state rides in g->snap (saved by the
-                 * parker BEFORE it yielded) instead of a per-g tstate.
-                 *
-                 * parked_offqueue => the g parked off-queue (netpoll/chan/sleep)
-                 * and a wake_g will route it back through the global runq.  End
-                 * ownership now: this happens AFTER the snap was saved, and while
-                 * RUNNING a wake only set RUNNING_WOKEN (never enqueued), so no
-                 * other hub could pull the g and load a half-saved snap.  CAS
-                 * RUNNING->PARKED so a later wake enqueues it; if a wake already
-                 * landed (RUNNING_WOKEN), enqueue exactly once now. */
-                if (parked_offqueue) {
-                    int rexp = RUNLOOM_WS_RUNNING;
-                    /* Detach the g's ref-holding interpreter state from THIS
-                     * hub's tstate now -- still RUNNING (sole owner), BEFORE the
-                     * g becomes migratable.  The parker already saved g->snap,
-                     * which owns its OWN refs to context / current_exception /
-                     * exc_value; loading the hub's clean base here drops this
-                     * hub's duplicate refs (rebalancing them).  Without it the
-                     * origin hub and the stealing hub (which loads the snap) both
-                     * own the g's exception and race its refcount -> the freed
-                     * object surfaces as "error return without exception set" /
-                     * SEGV deep in CPython's exception machinery.  This is the
-                     * snap-mode analogue of per-g-tstate's PyEval_SaveThread
-                     * (detach) before the RUNNING->PARKED transition.  Re-snap to
-                     * keep hub_snap valid for the next g. */
-                    runloom_pystate_load(&hub_snap);
-                    runloom_pystate_snap(&hub_snap);
-                    if (runloom_g_state_in(g, RUNLOOM_GST_MASK_PARKED)) {
-                        /* madvise idle stack below sp while still RUNNING (sole
-                         * owner -- a wake only flips RUNNING->RUNNING_WOKEN), so
-                         * no hub can resume into pages mid-drop.  Cross-hub-safe
-                         * for the same reason the sweep handshake is.  No-op
-                         * unless RUNLOOM_STACK_PARK_DONTNEED=1. */
-                        runloom_coro_park(g->coro);
-                    }
-                    if (__atomic_compare_exchange_n(&g->wake_state, &rexp,
-                                                    RUNLOOM_WS_PARKED, 0,
-                                                    __ATOMIC_ACQ_REL,
-                                                    __ATOMIC_ACQUIRE)) {
-                        RUNLOOM_WS_NOTE(RUNLOOM_WS_RUNNING, RUNLOOM_WS_PARKED);
-                        if (from_runq) runloom_g_decref(g);   /* old queue ref */
-                    } else {
-                        /* rexp == RUNNING_WOKEN: a wake landed during the resume.
-                         * Re-arm a single entry and enqueue now (snap is saved),
-                         * exactly once -- no lost wake, no duplicate. */
-                        RUNLOOM_WS_NOTE(RUNLOOM_WS_RUNNING_WOKEN, RUNLOOM_WS_QUEUED);
-                        __atomic_store_n(&g->wake_state, RUNLOOM_WS_QUEUED,
-                                         __ATOMIC_RELEASE);
-                        runloom_g_incref(g);                  /* new queue ref */
-                        runloom_mn_global_runq_push(g);
-                        if (from_runq) runloom_g_decref(g);   /* old queue ref */
-                    }
-                } else {
-                    /* Cooperative yield (sched_yield: already on local FIFO, or
-                     * raw runloom_coro_yield: push it here).  Holds no live parker,
-                     * so no wake_g can race -- stays RUNNING, hub-pinned. */
-                    RUNLOOM_WS_NOTE(RUNLOOM_WS_RUNNING, RUNLOOM_WS_RUNNING);
-                    __atomic_store_n(&g->wake_state, RUNLOOM_WS_RUNNING,
-                                     __ATOMIC_RELEASE);
-                    if (from_runq) runloom_g_decref(g);       /* old queue ref */
-                    if (!self_queued) runloom_sched_ready_push(&h->sched, g);
-                }
             } else if (!self_queued) {
                 /* Raw runloom_coro_yield() -- g didn't go through
                  * sched_yield to push itself.  Keep it alive on the

--- a/src/runloom_c/mn_sched_hub_main.c.inc
+++ b/src/runloom_c/mn_sched_hub_main.c.inc
@@ -1290,7 +1290,7 @@ static RUNLOOM_THREAD_RET runloom_hub_main(void *arg)
                                     "thread %lu but bound to %lu WITHOUT a mimalloc "
                                     "abandon/adopt handshake -> _mi_page_retire "
                                     "corruption is imminent (g id=%lld). See "
-                                    "docs/dev/STEAL_WOKEN_CLEANUP.md.\n",
+                                    "src/patches/README.md.\n",
                                     tid, g->tstate_owner_tid, (long long)g->id);
                                 fflush(stderr);
                             }

--- a/src/runloom_c/mn_sched_hub_main.c.inc
+++ b/src/runloom_c/mn_sched_hub_main.c.inc
@@ -1261,19 +1261,30 @@ static RUNLOOM_THREAD_RET runloom_hub_main(void *arg)
                  * instead of surfacing as a random teardown SEGV.  A correct
                  * handshake would update tstate_owner_tid on adopt, keeping it quiet. */
                 {
+                    /* Atomic lazy init: every hub thread reaches this on its
+                     * first per-g-tstate resume, so a plain `dbg < 0` read races
+                     * the first-init store across hubs.  Benign (same value) but
+                     * a real TSan data race -- caught by the pydebug+TSan build
+                     * once migration made this path reachable.  Same fix as the
+                     * ctx_copy static in runloom_g_entry. */
                     static int dbg = -1;
-                    if (dbg < 0) {
+                    int dbgv = __atomic_load_n(&dbg, __ATOMIC_RELAXED);
+                    if (dbgv < 0) {
                         const char *e = getenv("RUNLOOM_DBG_MIGRATE");
-                        dbg = (e != NULL && e[0] != '0' && e[0] != '\0') ? 1 : 0;
+                        dbgv = (e != NULL && e[0] != '0' && e[0] != '\0') ? 1 : 0;
+                        __atomic_store_n(&dbg, dbgv, __ATOMIC_RELAXED);
                     }
-                    if (dbg) {
+                    if (dbgv) {
                         unsigned long tid = (unsigned long)PyThread_get_thread_ident();
                         if (g->tstate_owner_tid == 0) {
                             g->tstate_owner_tid = tid;        /* first use: binds here */
                         } else if (g->tstate_owner_tid != tid) {
+                            /* Same story as `dbg` above: several hubs can reach
+                             * this concurrently, so claim the single warning
+                             * with an exchange rather than a racing test-and-set
+                             * (which both races and can warn more than once). */
                             static int warned = 0;
-                            if (!warned) {
-                                warned = 1;
+                            if (__atomic_exchange_n(&warned, 1, __ATOMIC_RELAXED) == 0) {
                                 fprintf(stderr,
                                     "[RUNLOOM_DBG_MIGRATE] per-g PyThreadState used on "
                                     "thread %lu but bound to %lu WITHOUT a mimalloc "

--- a/src/runloom_c/mn_sched_init_fini.c.inc
+++ b/src/runloom_c/mn_sched_init_fini.c.inc
@@ -153,7 +153,7 @@ int runloom_mn_init(int n_threads)
      * is structurally unsound (a suspended fiber's eval frames bake in the origin
      * hub's tstate pointer, which the snap cannot re-root, so a migrated fiber
      * drives the origin hub's tstate from a foreign OS thread -- TSan-proven data
-     * race -> SEGV; see docs/dev/STEAL_WOKEN_CLEANUP.md).  Per-g-tstate delivers
+     * race -> SEGV; see src/patches/README.md).  Per-g-tstate delivers
      * the SAME goal (any idle hub may resume a wedged hub's woken fiber, closing
      * the wedged-hub strand) CORRECTLY -- each fiber owns a migratable tstate that
      * is valid on any hub.  So RUNLOOM_STEAL_WOKEN now enables per-g-tstate and the

--- a/src/runloom_c/mn_sched_runq.c.inc
+++ b/src/runloom_c/mn_sched_runq.c.inc
@@ -258,37 +258,69 @@ static int runloom_migration_flag(void)
  * == 0 and runloom_use_global_runq() false -> default scheduler (and, crucially,
  * NOT the unsound snap-migration branch).
  *
- * SAFETY GATE (two-tier):
- *  - PRODUCTION: built against the alloc-home CPython patch (Py_TSTATE_ALLOC_HOME,
+ * SAFETY GATE (two-tier).  PRODUCTION requires BOTH optional CPython patches --
+ * they fix independent halves of the same problem and either alone still
+ * corrupts:
+ *  - ALLOCATION half -- alloc-home (Py_TSTATE_ALLOC_HOME,
  *    runloom_alloc_home_active()).  Each per-g tstate borrows the running hub's
- *    heap, so no heap migrates OS threads -- the crash that gated this mode is
- *    gone (validated: experiments/resume_rebuild/mpmc_pergt_repro.py 24/24 + a
- *    direct migration proof 50/60 cross-hub, zero crash).  Enable WITHOUT any
- *    unsafe override.  This is the supported way to ship migration.
- *  - STOCK CPython (no patch): per-g migration still corrupts (the per-g tstate's
- *    mimalloc heap migrates across hub threads -> SEGV under churn at H>=2; see
- *    docs/dev/STEAL_WOKEN_CLEANUP.md).  Keep the DEV/FUZZ gate: activate only with
- *    RUNLOOM_ALLOW_UNSAFE_MIGRATION=1.  Otherwise warn + run the default
- *    scheduler, so a production user who flips the flag on an unpatched
- *    interpreter gets a clean fallback, never a segfault. */
+ *    heap, so no heap migrates OS threads (validated:
+ *    experiments/resume_rebuild/mpmc_pergt_repro.py 24/24 + a direct migration
+ *    proof 50/60 cross-hub, zero crash).
+ *  - EXECUTION half -- exec-home (Py_TSTATE_EXEC_HOME,
+ *    runloom_exec_home_active(), patches/cpython314t-tstate-exec-home.patch).
+ *    Without it the compiler hoists/CSEs the two reads that identify the OS
+ *    thread a frame runs on: a resumed fiber keeps using the ORIGIN hub's
+ *    PyThreadState (freed outright if that hub has exited), and
+ *    _Py_IsOwnedByCurrentThread() resolves against a stale thread id, routing
+ *    decrefs down the non-atomic ob_ref_local path from the wrong thread ->
+ *    lost/duplicated decrements -> use-after-free.  alloc-home does NOT cover
+ *    this: it relocates the heap but leaves both reads cacheable.
+ * With both present, enable WITHOUT any unsafe override -- the supported way to
+ * ship migration.  Missing either (including stock CPython): keep the DEV/FUZZ
+ * gate, activate only with RUNLOOM_ALLOW_UNSAFE_MIGRATION=1.  Otherwise warn +
+ * run the default scheduler, so a user who flips the flag on an under-patched
+ * interpreter gets a clean fallback, never a segfault.
+ *
+ * CAVEAT the probes cannot express: exec-home is a CODEGEN property, and
+ * _Py_ThreadId() is inlined into Py_INCREF/Py_DECREF through the public
+ * refcount.h.  runloom_exec_home_active() speaks only for runloom_c's own
+ * translation units; any OTHER extension module in the process that was built
+ * against unpatched headers still carries cacheable reads in its refcounting.
+ * A fully sound migrating process needs every extension rebuilt against the
+ * patched interpreter. */
 static int runloom_resolve_migratable_mode(void)
 {
     int want = runloom_per_g_tstate_flag() || runloom_steal_woken_flag()
                || runloom_migration_flag();
+    int have_alloc, have_exec;
     if (!want) return 0;
-    /* Production: the patch makes it heap-safe -> enable, no override needed. */
-    if (runloom_alloc_home_active()) return 1;
-    /* Stock CPython: still unsound -> require the explicit dev escape hatch. */
+    have_alloc = runloom_alloc_home_active();
+    have_exec  = runloom_exec_home_active();
+    /* Production: both halves patched -> enable, no override needed. */
+    if (have_alloc && have_exec) return 1;
+    /* Anything less is still unsound -> require the explicit dev escape hatch. */
     if (runloom_unsafe_migration_acked()) return 1;
     fprintf(stderr,
         "[runloom] cross-hub migration (RUNLOOM_MIGRATION / RUNLOOM_PER_G_TSTATE / "
-        "RUNLOOM_STEAL_WOKEN) is GATED OFF: this CPython lacks the alloc-home patch, so a "
-        "per-g PyThreadState's mimalloc heap would migrate across hub threads -> "
-        "SEGV under churn at H>=2 (see docs/dev/STEAL_WOKEN_CLEANUP.md). For "
-        "PRODUCTION, build against patches/cpython313t-tstate-alloc-home.patch "
-        "(makes it heap-safe). For dev/fuzzing on stock CPython, set "
-        "RUNLOOM_ALLOW_UNSAFE_MIGRATION=1 to enable anyway. Running the default "
-        "(per-hub-tstate) scheduler instead.\n");
+        "RUNLOOM_STEAL_WOKEN) is GATED OFF: this CPython is missing %s.\n"
+        "  alloc-home (Py_TSTATE_ALLOC_HOME): %s -- without it a per-g "
+        "PyThreadState's mimalloc heap migrates across hub threads -> SEGV under "
+        "churn at H>=2.\n"
+        "  exec-home  (Py_TSTATE_EXEC_HOME):  %s -- without it the compiler caches "
+        "_PyThreadState_GET()/_Py_ThreadId() across a park/resume, so a migrated "
+        "fiber uses the origin hub's thread state and mis-resolves biased-refcount "
+        "ownership -> use-after-free.\n"
+        "For PRODUCTION, build CPython against BOTH "
+        "patches/cpython313t-tstate-alloc-home.patch and "
+        "patches/cpython314t-tstate-exec-home.patch (and rebuild extension modules "
+        "against it -- _Py_ThreadId() inlines into Py_INCREF/Py_DECREF). For "
+        "dev/fuzzing, set RUNLOOM_ALLOW_UNSAFE_MIGRATION=1 to enable anyway. "
+        "Running the default (per-hub-tstate) scheduler instead.\n",
+        (!have_alloc && !have_exec) ? "both migration patches"
+                                    : (!have_alloc ? "the alloc-home patch"
+                                                   : "the exec-home patch"),
+        have_alloc ? "present" : "MISSING",
+        have_exec  ? "present" : "MISSING");
     return 0;
 }
 

--- a/src/runloom_c/mn_sched_runq.c.inc
+++ b/src/runloom_c/mn_sched_runq.c.inc
@@ -168,7 +168,7 @@ static runloom_g_t *runloom_mn_global_runq_pull(void)
  * owning hub's tstate into the suspended frames).  Trades memory (a tstate per
  * g) for a closeable p99.9 tail.  KNOWN CRASH under churn at H>=2 (the per-g
  * tstate's mimalloc heap migrates across hub threads -> SEGV; see the "KNOWN
- * BUG" block in runloom_sched_core.c.inc and docs/dev/STEAL_WOKEN_CLEANUP.md), so
+ * BUG" block in runloom_sched_core.c.inc and src/patches/README.md), so
  * mn_init runs this flag through runloom_resolve_migratable_mode: it activates
  * ONLY with RUNLOOM_ALLOW_UNSAFE_MIGRATION=1, else warns + stays off.  Read once. */
 static int runloom_per_g_tstate_flag(void)
@@ -191,7 +191,7 @@ static int runloom_per_g_tstate_flag(void)
  * pointer (in registers / C locals on the coro stack), which the snap cannot
  * re-root; the migrated fiber then drives the origin hub's tstate from a foreign
  * OS thread (TSan-proven data race on datastack_chunk / c_recursion_remaining /
- * current_exception -> SEGV; H>=2 only).  See docs/dev/STEAL_WOKEN_CLEANUP.md.
+ * current_exception -> SEGV; H>=2 only).  See src/patches/README.md.
  *
  * The flag is therefore REDIRECTED: mn_init enables RUNLOOM_PER_G_TSTATE when this
  * is set (see mn_sched_init_fini.c.inc), so RUNLOOM_STEAL_WOKEN=1 runs the per-g-

--- a/src/runloom_c/module_init.c.inc
+++ b/src/runloom_c/module_init.c.inc
@@ -666,18 +666,32 @@ PyMODINIT_FUNC PyInit_runloom_c(void)
         Py_DECREF(m);
         return NULL;
     }
-    /* Capability probe for cross-hub fiber migration: 1 iff this build was
-     * compiled against the alloc-home CPython patch (Py_TSTATE_ALLOC_HOME) and
-     * the borrow isn't disabled (RUNLOOM_NO_ALLOC_HOME).  When 1, RUNLOOM_MIGRATION
-     * is safe to enable for production; when 0 (stock CPython) migration is only
-     * reachable via the RUNLOOM_ALLOW_UNSAFE_MIGRATION dev override.  The Python
-     * layer reads this in runloom.migration_available()/enable_migration().
-     * runloom_alloc_home_active is defined in runloom_iframe.c (extern, same
-     * pattern as runloom_immortalize in module_run.c.inc). */
+    /* Capability probes for cross-hub fiber migration.  Migration needs BOTH
+     * optional CPython patches, because they fix independent halves of the same
+     * problem:
+     *   alloc_home_available -- Py_TSTATE_ALLOC_HOME: a migrated fiber allocates
+     *     on the hub now running it, so no per-fiber mimalloc heap migrates OS
+     *     threads (the _mi_page_retire teardown corruption).
+     *   exec_home_available  -- Py_TSTATE_EXEC_HOME: _PyThreadState_GET() and
+     *     _Py_ThreadId() stay non-cacheable, so a resumed fiber cannot keep
+     *     using the ORIGIN hub's thread state or resolve biased-refcount
+     *     ownership against a stale thread id (a use-after-free).
+     * Either alone is insufficient; the scheduler's interlock requires both for
+     * the un-overridden production path, else migration stays behind
+     * RUNLOOM_ALLOW_UNSAFE_MIGRATION.  The Python layer reads these in
+     * runloom.migration_available()/enable_migration().  Both are defined in
+     * runloom_iframe.c (extern, same pattern as runloom_immortalize in
+     * module_run.c.inc). */
     {
         extern int runloom_alloc_home_active(void);
+        extern int runloom_exec_home_active(void);
         if (PyModule_AddIntConstant(m, "alloc_home_available",
                                     runloom_alloc_home_active()) < 0) {
+            Py_DECREF(m);
+            return NULL;
+        }
+        if (PyModule_AddIntConstant(m, "exec_home_available",
+                                    runloom_exec_home_active()) < 0) {
             Py_DECREF(m);
             return NULL;
         }

--- a/src/runloom_c/runloom_iframe.c
+++ b/src/runloom_c/runloom_iframe.c
@@ -97,6 +97,15 @@ int runloom_alloc_home_active(void)
 #endif
 }
 
+int runloom_exec_home_active(void)
+{
+#if defined(Py_GIL_DISABLED) && defined(Py_TSTATE_EXEC_HOME) && defined(_Py_TID_ASM)
+    return 1;
+#else
+    return 0;
+#endif
+}
+
 void runloom_iframe_borrow_alloc_home(PyThreadState *exec, PyThreadState *home)
 {
 #if defined(Py_GIL_DISABLED) && defined(Py_TSTATE_ALLOC_HOME)

--- a/src/runloom_c/runloom_iframe.h
+++ b/src/runloom_c/runloom_iframe.h
@@ -97,13 +97,33 @@ void runloom_immortalize(PyObject *op);
  * no-op against stock CPython, so the call site is unconditional. */
 void runloom_iframe_borrow_alloc_home(PyThreadState *exec, PyThreadState *home);
 
-/* True iff this build can SAFELY migrate fibers across hubs: compiled against the
+/* True iff this build's ALLOCATION half is migration-safe: compiled against the
  * alloc-home CPython patch (Py_TSTATE_ALLOC_HOME) and not disabled at runtime
- * (RUNLOOM_NO_ALLOC_HOME).  The scheduler's migratable-mode interlock uses this as
- * the production gate -- when true, RUNLOOM_MIGRATION enables without the unsafe
- * override; against stock CPython it returns 0 and migration stays dev-gated.
- * Exposed to Python as runloom_c.alloc_home_available. */
+ * (RUNLOOM_NO_ALLOC_HOME).  Necessary but NOT sufficient on its own -- see
+ * runloom_exec_home_active below.  Exposed as runloom_c.alloc_home_available. */
 int runloom_alloc_home_active(void);
+
+/* True iff this build's EXECUTION half is migration-safe: compiled against the
+ * exec-home CPython patch (Py_TSTATE_EXEC_HOME,
+ * patches/cpython314t-tstate-exec-home.patch).
+ *
+ * Without it the compiler may hoist/CSE the two reads that identify the OS
+ * thread a frame runs on -- _PyThreadState_GET() and _Py_ThreadId() -- across a
+ * fiber's park/resume.  A migrated fiber then keeps using the ORIGIN hub's
+ * thread state (possibly freed, if that hub exited) and, worse, resolves
+ * _Py_IsOwnedByCurrentThread() against a stale thread id, sending decrefs down
+ * the non-atomic ob_ref_local path from the wrong thread -> lost/duplicated
+ * decrements -> use-after-free.  alloc-home does not help: it moves the HEAP to
+ * the running hub but leaves both reads cacheable.
+ *
+ * NOTE this is a property of how THIS EXTENSION was compiled, not just of the
+ * interpreter: _Py_ThreadId() is inlined into Py_INCREF/Py_DECREF via the public
+ * refcount.h, so every extension module in the process must be rebuilt against
+ * the patched headers for the guarantee to hold process-wide.  This probe can
+ * only speak for runloom_c itself.
+ *
+ * Exposed to Python as runloom_c.exec_home_available. */
+int runloom_exec_home_active(void);
 
 #if PY_VERSION_HEX >= 0x030E0000
 /* 3.14: arm the SP-based C-stack overflow check at fiber c's private stack, with

--- a/src/runloom_c/runloom_kcsan.h
+++ b/src/runloom_c/runloom_kcsan.h
@@ -36,8 +36,11 @@ void runloom_kcsan_violation(const char *where, uint64_t before, uint64_t after)
 
 /* ASSERT_EXCLUSIVE_ACCESS on a 64-bit atomic word: the caller asserts nothing
  * else writes *p for the duration of this window.  Sampled. */
+/* p is a plain uint64_t*, not _Atomic-qualified: the __atomic_* builtins below
+ * supply the atomicity, and clang >= ~18 rejects _Atomic(T)* operands to them
+ * (see the note in rl_handle.c). */
 RUNLOOM_INLINE void runloom_kcsan_check64(const char *where,
-                                          const _Atomic uint64_t *p)
+                                          const uint64_t *p)
 {
     uint64_t before, after;
     if ((++runloom_kcsan_ctr & (RUNLOOM_KCSAN_N - 1u)) != 0u) return;

--- a/src/runloom_c/runloom_sched.h
+++ b/src/runloom_c/runloom_sched.h
@@ -121,14 +121,6 @@ struct runloom_pystate_snap {
      * _PyErr_SetObject during the next exception cascade (e.g., async
      * function's StopIteration on return). */
     PyObject *current_exception;
-    /* Cross-hub snap migration (RUNLOOM_STEAL_WOKEN): when the g suspended inside
-     * active exception handling (exc_info != &tstate->exc_state), the bottom
-     * per-g _PyErr_StackItem's previous_item points at the ORIGIN hub tstate's
-     * &exc_state -- hub-bound.  Recorded here at snap so load can re-root it
-     * onto the TARGET hub's &exc_state.  NULL in the common exc_info==base case.
-     * Borrowed (the item lives in a per-g gen/coro object kept alive by the g's
-     * frames); no ref held. */
-    _PyErr_StackItem *exc_chain_bottom;
     /* p69 residual UAF: each _PyErr_StackItem in the saved exc_info chain that is
      * NOT the tstate-embedded &exc_state is embedded inside a generator/coroutine
      * object's gi_exc_state.  The mac fix borrowed those items, ASSUMING the g's
@@ -196,13 +188,6 @@ struct runloom_pystate_snap {
      * runloom_iframe.c does the typed access). */
     void *c_stack_refs;
 #endif
-    /* DIAG (RUNLOOM_DIAG_MIGRATE): the PyThreadState bound when this snap was
-     * saved -- i.e. the tstate pointer baked into the g's suspended CPython
-     * eval-loop C frame.  A cross-hub resume loads the snap onto a DIFFERENT
-     * bound tstate; if current_frame != NULL the eval loop still threads this
-     * origin_tstate while the bound tstate differs -> the H>=2 corruption.
-     * Borrowed pointer; compared, never dereferenced through here. */
-    PyThreadState *origin_tstate;
 };
 
 /* One fiber (the "G" in Go's M:P:G nomenclature).

--- a/src/runloom_c/runloom_sched_core.c.inc
+++ b/src/runloom_c/runloom_sched_core.c.inc
@@ -894,35 +894,41 @@ void runloom_g_decref(runloom_g_t *g)
              * held -- runloom_g_decref's contexts (hub completion, drain, RunloomG
              * dealloc) all run with some other tstate current.
              *
-             * ============================ KNOWN BUG ============================
+             * =================== UNPATCHED-INTERPRETER CRASH ===================
              * If you arrived here from a SEGV backtrace that goes
              *   PyThreadState_Clear -> _PyMem_AbandonDelayed -> ... -> _mi_page_retire
-             * STOP -- this is a CHARACTERIZED, NOT-YET-FIXED bug.  Do not re-derive
-             * it; read docs/dev/STEAL_WOKEN_CLEANUP.md ("Tracked bug" + "Fix design").
+             * you forced a migratable mode on an interpreter that LACKS the
+             * alloc-home patch -- i.e. RUNLOOM_ALLOW_UNSAFE_MIGRATION=1 enabled it
+             * despite runloom.migration_available() being False.  This crash is
+             * CHARACTERIZED and FIXED by the alloc-home patch (src/patches/
+             * README.md); do not re-derive it.
              *
              * What it is: this Clear is NOT the cause.  Under RUNLOOM_PER_G_TSTATE
-             * (and RUNLOOM_STEAL_WOKEN, which redirects to it) a fiber's per-g
-             * PyThreadState -- carrying its OWN mimalloc heap + QSBR delayed-free
-             * state -- migrates across OS hub threads as the fiber moves hub->hub.
-             * Free-threaded CPython binds a tstate's allocator to ONE OS thread
-             * (PyThreadState_Bind; mimalloc keys page ownership on _Py_ThreadId).
-             * Migrating it without the mimalloc segment abandon/adopt handshake
-             * leaves the heap's per-thread bookkeeping inconsistent; the corruption
-             * just SURFACES here, when Clear abandons the delayed-free queue and
-             * retires an already-inconsistent page.
+             * (and RUNLOOM_STEAL_WOKEN / RUNLOOM_MIGRATION, which map to it) a
+             * fiber's per-g PyThreadState -- carrying its OWN mimalloc heap + QSBR
+             * delayed-free state -- migrates across OS hub threads as the fiber
+             * moves hub->hub.  Free-threaded CPython binds a tstate's allocator to
+             * ONE OS thread (PyThreadState_Bind; mimalloc keys page ownership on
+             * _Py_ThreadId).  Migrating the heap leaves its per-thread bookkeeping
+             * inconsistent; the corruption just SURFACES here, when Clear abandons
+             * the delayed-free queue and retires an already-inconsistent page.
              *
              * Fingerprint: intermittent SEGV, ONLY at H>=2 (needs real migration --
              * H=1 is always clean), ONLY under allocation churn (e.g.
-             * test_chan_queue MPMC).  The DEFAULT scheduler (both flags off) never
+             * test_chan_queue MPMC).  The DEFAULT scheduler (all flags off) never
              * takes this path and is unaffected.
              *
-             * Do NOT try to "fix" it here (teardown) or by reordering Clear/Delete
-             * or making g->tstate current first -- the pages are already corrupt by
-             * the time we get here.  The only real fix is the mimalloc + brc + qsbr
-             * thread abandon/adopt handshake at each park/resume boundary (see the
-             * hub_main per-g-tstate branch + the "Fix design" doc section); it is a
-             * dedicated, validated effort, not a patch.  Until then the migratable
-             * modes stay opt-in / experimental.
+             * THE FIX -- alloc-home (Py_TSTATE_ALLOC_HOME).  Each per-g tstate
+             * borrows the RUNNING hub's allocator on every resume
+             * (runloom_iframe_borrow_alloc_home, hub_main per-g branch), so its own
+             * heap stays empty and never migrates OS threads -- no _mi_page_retire
+             * corruption.  With BOTH patches present (migration_available()) the
+             * mode enables with no override and this path is SOUND; the crash above
+             * is reachable ONLY via the RUNLOOM_ALLOW_UNSAFE_MIGRATION dev/fuzzing
+             * escape hatch on an under-patched interpreter.  Do NOT try to "fix" it
+             * here (teardown) or by reordering Clear/Delete -- unpatched, the pages
+             * are already corrupt by the time we reach this line; the fix is the
+             * patch, not this teardown.
              * ==================================================================*/
             PyThreadState_Clear(g->tstate);
             PyThreadState_Delete(g->tstate);

--- a/src/runloom_c/runloom_sched_pystate.c.inc
+++ b/src/runloom_c/runloom_sched_pystate.c.inc
@@ -91,11 +91,6 @@ void runloom_pystate_snap(runloom_pystate_snap_t *snap)
      * No-op unless RUNLOOM_DELAY names this site. */
     runloom_delay_inject(RUNLOOM_DLY_SNAP_SAVE);
 
-    /* DIAG: remember which tstate is bound right now.  This is the pointer
-     * the suspended eval loop bakes into its C frame; load checks it for a
-     * cross-hub mismatch.  Cheap unconditional store (one word). */
-    snap->origin_tstate = ts;
-
     /* Suspend any CPython critical section this g holds (free-threaded 3.13t):
      * release the held per-object mutexes and save the chain so load can
      * re-lock them on resume.  Common case (no CS held at a park point) is one
@@ -165,34 +160,27 @@ void runloom_pystate_snap(runloom_pystate_snap_t *snap)
     if (__builtin_expect(ts->exc_info == &ts->exc_state &&
                          ts->exc_state.exc_value == NULL, 1)) {
         snap->exc_info = NULL;
-        snap->exc_chain_bottom = NULL;
         snap->exc_owner_count = 0;
     } else {
         snap->exc_info = ts->exc_info;
         snap->exc_state = ts->exc_state;
         Py_XINCREF(snap->exc_state.exc_value);
         /* Walk the exc_info chain ONCE, from the head (ts->exc_info) down to the
-         * tstate-embedded &exc_state, doing two things:
-         *   (1) record exc_chain_bottom -- the item whose previous_item roots at
-         *       THIS tstate's &exc_state -- so a cross-hub load (steal-woken) can
-         *       re-root it onto the target hub's tstate; and
-         *   (2) PIN the owner of every NON-base item with a strong ref (p69
-         *       residual UAF).  An item that is not &ts->exc_state is embedded in
-         *       a generator/coroutine/async-gen object's *_exc_state field, all at
-         *       the SAME byte offset (shared _PyGenObject_HEAD layout), so the
-         *       owning object is item - offsetof(PyGenObject, gi_exc_state).  We
-         *       type-check that recovered pointer before trusting the offset, then
-         *       INCREF it so a transient gen (e.g. extract_tb's internal
-         *       _extract_from_extended_frame_gen) cannot be freed while this fiber
-         *       is parked mid-iteration -- which would otherwise leave snap->exc_info
-         *       and the previous_item links dangling, and load would re-install a
-         *       wild ts->exc_info (the p69/p69b AV under preemption).
-         * Bounded walk (chain depth = coroutine nesting).  exc_chain_bottom stays
-         * NULL if the chain doesn't root here (defensive; load then skips re-root). */
+         * tstate-embedded &exc_state, to PIN the owner of every NON-base item
+         * with a strong ref (p69 residual UAF).  An item that is not
+         * &ts->exc_state is embedded in a generator/coroutine/async-gen object's
+         * *_exc_state field, all at the SAME byte offset (shared _PyGenObject_HEAD
+         * layout), so the owning object is item - offsetof(PyGenObject,
+         * gi_exc_state).  We type-check that recovered pointer before trusting the
+         * offset, then INCREF it so a transient gen (e.g. extract_tb's internal
+         * _extract_from_extended_frame_gen) cannot be freed while this fiber is
+         * parked mid-iteration -- which would otherwise leave snap->exc_info and
+         * the previous_item links dangling, and load would re-install a wild
+         * ts->exc_info (the p69/p69b AV under preemption).
+         * Bounded walk (chain depth = coroutine nesting). */
         {
             _PyErr_StackItem *it = ts->exc_info;
             int guard = 0;
-            snap->exc_chain_bottom = NULL;
             snap->exc_owner_count = 0;
             while (it != NULL && it != &ts->exc_state && guard++ < 256) {
                 if (snap->exc_owner_count <
@@ -209,10 +197,8 @@ void runloom_pystate_snap(runloom_pystate_snap_t *snap)
                         snap->exc_owners[snap->exc_owner_count++] = owner;
                     }
                 }
-                if (it->previous_item == &ts->exc_state) {
-                    snap->exc_chain_bottom = it;
-                    break;
-                }
+                if (it->previous_item == &ts->exc_state)
+                    break;   /* reached the tstate-embedded base; done */
                 it = it->previous_item;
             }
         }
@@ -359,36 +345,6 @@ void runloom_pystate_load(runloom_pystate_snap_t *snap)
     runloom_critsec_restore(ts, snap->critical_section);
     snap->critical_section = 0;
 
-    /* DIAG (RUNLOOM_DIAG_MIGRATE=1): detect the H>=2 cross-hub corruption at its
-     * SOURCE.  When we load a snap onto a tstate that differs from the one the
-     * snap was saved on (origin_tstate) AND the g has live Python frames
-     * (current_frame != NULL on 3.13), the g's suspended eval loop will keep
-     * threading origin_tstate while the bound tstate is `ts` -> divergent
-     * exception/datastack reads -> "error return without exception set" / SEGV.
-     * This fires immediately BEFORE the crash, naming both tstates. */
-    {
-        static int diag = -1;
-        int d = __atomic_load_n(&diag, __ATOMIC_RELAXED);
-        if (d < 0) {
-            const char *e = getenv("RUNLOOM_DIAG_MIGRATE");
-            d = (e != NULL && e[0] != '0') ? 1 : 0;
-            __atomic_store_n(&diag, d, __ATOMIC_RELAXED);
-        }
-        if (d && snap->origin_tstate != ts) {
-            void *frame = NULL;
-#if PY_VERSION_HEX >= 0x030D0000
-            frame = (void *)snap->current_frame;
-#endif
-            fprintf(stderr,
-                "[RUNLOOM_DIAG_MIGRATE] cross-hub snap load: origin_ts=%p "
-                "bound_ts=%p live_frame=%p exc_info=%p cur_exc=%p%s\n",
-                (void *)snap->origin_tstate, (void *)ts, frame,
-                (void *)snap->exc_info, (void *)snap->current_exception,
-                frame != NULL ? "  <-- LIVE FRAME: eval loop will use stale "
-                                "origin_ts (CORRUPTION)" : "  (no live frame)");
-        }
-    }
-
 #if PY_VERSION_HEX >= 0x030B0000
     /* contextvars fast path: if g didn't touch ts->context, the snap's
      * pointer matches ts's.  Drop our extra ref and skip the swap +
@@ -463,15 +419,6 @@ void runloom_pystate_load(runloom_pystate_snap_t *snap)
         Py_XDECREF(ts->exc_state.exc_value);
         ts->exc_state = snap->exc_state;
         ts->exc_info = snap->exc_info;
-        /* Re-root the bottom per-g exc item onto THIS hub's &exc_state.  Same-hub
-         * load: &ts->exc_state is the address snap recorded -- a no-op store.
-         * Cross-hub (steal-woken): fixes the previous_item that still pointed at
-         * the ORIGIN hub's tstate, which would otherwise dangle when the g's
-         * generator/coroutine unwinds its exception context on the new hub. */
-        if (snap->exc_chain_bottom != NULL) {
-            snap->exc_chain_bottom->previous_item = &ts->exc_state;
-            snap->exc_chain_bottom = NULL;
-        }
         snap->exc_info = NULL;
         snap->exc_state.exc_value = NULL;       /* ownership transferred */
         snap->exc_state.previous_item = NULL;
@@ -548,7 +495,6 @@ void runloom_pystate_snap_clear(runloom_pystate_snap_t *snap)
     Py_CLEAR(snap->context);
     Py_CLEAR(snap->exc_state.exc_value);
     snap->exc_info = NULL;
-    snap->exc_chain_bottom = NULL;
     /* Drop the gen/coro owners pinned across the suspension (p69 residual UAF). */
     while (snap->exc_owner_count > 0) {
         Py_DECREF(snap->exc_owners[--snap->exc_owner_count]);

--- a/tests/test_cov100_hub_main.py
+++ b/tests/test_cov100_hub_main.py
@@ -326,9 +326,14 @@ def test_per_g_tstate_is_gated_off_without_ack():
         "workload did not complete under the gated-off fallback.\nstdout=%s" % p.stdout)
     # The GATED-OFF warning is the proof that the per-g block (Group A) was NOT
     # entered: the flag was requested but the resolve interlock denied it.
-    assert "GATED OFF" in p.stderr, (
-        "expected the migratable-mode GATED-OFF warning (proves Group A stayed "
-        "unreachable without the ack); stderr=%s" % p.stderr[-1500:])
+    # It only applies on an interpreter MISSING a migration patch -- with both
+    # present (src/patches/) the request is supported, so the interlock enables
+    # the migratable block and prints nothing.  The no-crash + work-completes
+    # assertions above hold either way and are the real invariant.
+    if not runloom.migration_available():
+        assert "GATED OFF" in p.stderr, (
+            "expected the migratable-mode GATED-OFF warning (proves Group A stayed "
+            "unreachable without the ack); stderr=%s" % p.stderr[-1500:])
 
 
 if __name__ == "__main__":

--- a/tests/test_cov100_runq.py
+++ b/tests/test_cov100_runq.py
@@ -58,6 +58,8 @@ import sys
 
 import pytest
 
+import runloom
+
 from adv_util import hang_guard, needs_free_threading
 
 FT = needs_free_threading()
@@ -69,6 +71,15 @@ PY = sys.executable
 # vanish AND the workload would crash -- either way the test fails loudly.
 _WARN_NEEDLE = "GATED OFF"
 _ACK_HINT = "RUNLOOM_ALLOW_UNSAFE_MIGRATION=1 to enable anyway"
+
+# Whether the interpreter carries BOTH migration patches (src/patches/).  When it
+# does, requesting migration is a SUPPORTED configuration: the interlock enables
+# it and prints nothing, so the gated-off warn must NOT be asserted.  The
+# invariants that hold either way -- no crash, and every cross-hub wake delivered
+# -- are asserted unconditionally.
+_MIGRATION_OK = runloom.migration_available()
+_GATE_REASON = ("interpreter has both migration patches (%r); the gated-off warn "
+                "branch is unreachable here" % (runloom.migration_status(),))
 
 
 # A self-contained child program. It runs a workload that, under the *default*
@@ -185,10 +196,11 @@ def test_per_g_tstate_gated_off_uses_default_sched():
         "gated-off per-g-tstate child crashed (rc=%d) -- the interlock must run "
         "the DEFAULT scheduler, never the known-crash migration mode.\nstderr=%s"
         % (p.returncode, p.stderr[-2000:]))
-    assert _WARN_NEEDLE in p.stderr and _ACK_HINT in p.stderr, (
-        "resolve_migratable_mode did NOT take the gated-off warn branch "
-        "(L237-243); a silent flip to per-g-tstate would engage the global runq."
-        "\nstderr=%s" % p.stderr[-2000:])
+    if not _MIGRATION_OK:
+        assert _WARN_NEEDLE in p.stderr and _ACK_HINT in p.stderr, (
+            "resolve_migratable_mode did NOT take the gated-off warn branch "
+            "(L237-243); a silent flip to per-g-tstate would engage the global runq."
+            "\nstderr=%s" % p.stderr[-2000:])
     assert "CHILD_OK" in p.stdout, (
         "default scheduler did not deliver every cross-hub wake "
         "(channel + fd) -> work stranded.\nout=%s\nerr=%s"
@@ -209,10 +221,11 @@ def test_steal_woken_gated_off_uses_default_sched():
     assert p.returncode == 0, (
         "gated-off steal-woken child crashed (rc=%d).\nstderr=%s"
         % (p.returncode, p.stderr[-2000:]))
-    assert _WARN_NEEDLE in p.stderr and _ACK_HINT in p.stderr, (
-        "resolve_migratable_mode did NOT warn for RUNLOOM_STEAL_WOKEN "
-        "(its flag must feed the same gated-off branch).\nstderr=%s"
-        % p.stderr[-2000:])
+    if not _MIGRATION_OK:
+        assert _WARN_NEEDLE in p.stderr and _ACK_HINT in p.stderr, (
+            "resolve_migratable_mode did NOT warn for RUNLOOM_STEAL_WOKEN "
+            "(its flag must feed the same gated-off branch).\nstderr=%s"
+            % p.stderr[-2000:])
     assert "CHILD_OK" in p.stdout, (
         "default scheduler did not deliver every cross-hub wake under "
         "steal-woken.\nout=%s\nerr=%s" % (p.stdout, p.stderr[-1200:]))
@@ -235,10 +248,14 @@ def test_unsafe_ack_zero_is_not_acked():
         "ack='0' child crashed (rc=%d) -- '0' must be read as NOT acked, "
         "keeping the default scheduler.\nstderr=%s"
         % (p.returncode, p.stderr[-2000:]))
-    assert _WARN_NEEDLE in p.stderr, (
-        "RUNLOOM_ALLOW_UNSAFE_MIGRATION='0' was wrongly treated as acked: the "
-        "gated-off warn did not fire -> the known-crash migration mode would "
-        "have engaged.\nstderr=%s" % p.stderr[-2000:])
+    if not _MIGRATION_OK:
+        # Reachable only on an under-patched interpreter: with both patches the
+        # interlock returns 1 before it ever consults the ack, so the parser is
+        # not exercised here.  See _GATE_REASON.
+        assert _WARN_NEEDLE in p.stderr, (
+            "RUNLOOM_ALLOW_UNSAFE_MIGRATION='0' was wrongly treated as acked: the "
+            "gated-off warn did not fire -> the known-crash migration mode would "
+            "have engaged.\nstderr=%s" % p.stderr[-2000:])
     assert "CHILD_OK" in p.stdout, (
         "default sched did not finish the workload with ack='0'.\nout=%s\nerr=%s"
         % (p.stdout, p.stderr[-1200:]))

--- a/tests/test_cov_introspect_predicates.py
+++ b/tests/test_cov_introspect_predicates.py
@@ -2,9 +2,11 @@
 registry dump.  Three gaps the existing introspect suites don't pin:
 
   1. enable_migration() SAFETY CONTRACT on the shipped (unpatched) build.
-     migration_available() is False without the alloc-home CPython patch, so
-     enable_migration() must RAISE RuntimeError *and must not leave the process
-     armed* -- i.e. it must NOT set os.environ['RUNLOOM_MIGRATION'] on the way
+     migration_available() is False unless CPython was built with BOTH optional
+     patches -- alloc-home (Py_TSTATE_ALLOC_HOME) for the allocation half and
+     exec-home (Py_TSTATE_EXEC_HOME) for the execution half -- so on anything
+     less enable_migration() must RAISE RuntimeError *and must not leave the
+     process armed*: it must NOT set os.environ['RUNLOOM_MIGRATION'] on the way
      out (a half-applied flag would silently enable the crash-prone per-g-tstate
      path at the next run()).  Mirrors src/patches/README.md's stated contract.
 
@@ -62,18 +64,25 @@ class TestEnableMigrationRefusesOnShippedBuild:
 
     @pytest.mark.skipif(
         runloom.migration_available(),
-        reason="alloc-home-patched build: enable_migration() is allowed to "
-               "succeed here, so the 'must refuse' contract doesn't apply")
+        reason="fully patched build (alloc-home AND exec-home): "
+               "enable_migration() is allowed to succeed here, so the "
+               "'must refuse' contract doesn't apply")
     def test_raises_and_leaves_env_unset(self):
-        # Precondition: this is the shipped build (no patch).
+        # Precondition: this build is missing at least one migration patch.
         assert runloom.migration_available() is False
         assert "RUNLOOM_MIGRATION" not in os.environ
 
         with pytest.raises(RuntimeError) as ei:
             runloom.enable_migration()          # allow_unsafe defaults to False
 
-        # The refusal must name the alloc-home patch (the actionable remedy).
-        assert "alloc-home" in str(ei.value)
+        # The refusal must name every MISSING patch (the actionable remedy) --
+        # naming only one half would send the user off to a half-fix.
+        msg = str(ei.value)
+        status = runloom.migration_status()
+        if not status["alloc_home"]:
+            assert "alloc-home" in msg
+        if not status["exec_home"]:
+            assert "exec-home" in msg
 
         # THE contract: a refused call must NOT arm the flag.  A half-applied
         # RUNLOOM_MIGRATION=1 would enable the unsafe per-g-tstate path at the

--- a/tests/test_swarm_mn_sched.py
+++ b/tests/test_swarm_mn_sched.py
@@ -887,17 +887,28 @@ sys.stdout.write("MIGRATE_WARN_OK\n")
 @mn
 @pytest.mark.parametrize("flag", ["RUNLOOM_PER_G_TSTATE", "RUNLOOM_STEAL_WOKEN"])
 def test_gated_off_migratable_warns_and_runs_default(flag):
-    # The unsafe migratable mode must be GATED OFF without
-    # RUNLOOM_ALLOW_UNSAFE_MIGRATION: it warns to stderr and runs the safe
-    # default scheduler -- it must NOT crash and the workload must complete.
-    # (We NEVER set RUNLOOM_ALLOW_UNSAFE_MIGRATION -- that path is known-crash.)
+    # Whether the migratable mode is GATED OFF depends on the interpreter: it
+    # needs BOTH optional CPython patches (see src/patches/).  Either way the
+    # workload must complete and must NOT crash -- that is the invariant.
+    # (We NEVER set RUNLOOM_ALLOW_UNSAFE_MIGRATION -- on an under-patched
+    # interpreter that path is known-crash.)
     p = _run_script(_MIGRATE_WARN, {flag: "1"}, timeout=40)
     _assert_no_crash(p, "gated-off %s" % flag)
     assert "MIGRATE_WARN_OK" in p.stdout, (
-        "gated-off %s did not run the default scheduler to completion:\n%s\n%s"
+        "%s did not run to completion:\n%s\n%s"
         % (flag, p.stdout, p.stderr[-800:]))
-    assert "GATED OFF" in p.stderr, (
-        "gated-off %s did not emit the warn diagnostic:\n%s" % (flag, p.stderr[-800:]))
+    if runloom.migration_available():
+        # Fully patched: migration is supported, so it ACTIVATES silently.
+        # Warning here would be a false alarm on a correct production build.
+        assert "GATED OFF" not in p.stderr, (
+            "%s was gated off on a fully-patched interpreter (%r):\n%s"
+            % (flag, runloom.migration_status(), p.stderr[-800:]))
+    else:
+        # Missing a half -> warn to stderr and run the safe default scheduler,
+        # naming the gap so the user knows which patch to add.
+        assert "GATED OFF" in p.stderr, (
+            "gated-off %s did not emit the warn diagnostic (%r):\n%s"
+            % (flag, runloom.migration_status(), p.stderr[-800:]))
 
 
 # ==========================================================================


### PR DESCRIPTION
This resolves two issues reproduced by a simple work sharing reproduction

```
import runloom_c

HUBS, FIBERS, ROUNDS, ITERS = 4, 16, 20, 20


def body():
    ch = runloom_c.Chan(0)              # unbuffered -> recv() really parks
    res = runloom_c.Chan(FIBERS)

    def worker():
        for _ in range(ROUNDS):
            ch.recv()                   # park; any hub may resume us
        res.send(1)

    def feeder():
        for _ in range(ROUNDS * FIBERS):
            ch.send(1)

    runloom_c.mn_init(HUBS)
    for _ in range(FIBERS):
        runloom_c.mn_fiber(worker)
    runloom_c.mn_fiber(feeder)
    runloom_c.mn_run()
    for _ in range(FIBERS):
        if res.try_recv() is None:
            break
    runloom_c.mn_fini()


for _ in range(ITERS):
    body()
print("survived")
```
YTHONPATH=.venv-orig/ext:src RUNLOOM_MIGRATION=1 RUNLOOM_ALLOW_UNSAFE_MIGRATION=1 PYTHON_GIL=0 .venv-orig/bin/python tests/experiments/resume_rebuild/exec_home_min.py
[1]    92840 segmentation fault  PYTHONPATH=.venv-orig/ext:src RUNLOOM_MIGRATION=1 =1 PYTHON_GIL=0 

This was resolved down to compiler optimisations relating to   `_PyThreadState_GetCurrent()` and `_Py_ThreadId()`
In `_Py_ThreadId()`.

`_Py_ThreadId()` the threadId can become stale due to compiler optimising the actual evaluation and `_PyThreadState_GetCurrent()`  could return a stale `_Py_tss_tstate`
 
