### PR TITLE
feat(sched): deterministic hub placement for tests -- mn_fiber(hub=), G.pin()

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -122,8 +122,12 @@ Full derivations for the invariants below: [docs/dev/RUNTIME_GOTCHAS.md](docs/de
   offload (a slowdown, not a failure — the easiest one to reintroduce).
   `any_stealable_work` / `wakep_one` are bounded for the same reason. New spawn
   paths must route through `runloom_mn_fiber_core(..., force_hub)`, never a
-  second path, or the parked-frame GC blind spot below reopens. Guard:
-  `tests/test_offload_hubs.py`.
+  second path, or the parked-frame GC blind spot below reopens. The ONE
+  sanctioned breach is `mn_fiber(hub=N)`, bounded by `runloom_hub_count` not
+  `runloom_general_hub_count()`, so a test can force general work onto an
+  offload hub and assert the exclusions from the inside. Liveness only — pinned
+  to a BUSY offload hub the fiber strands; nothing migrates, so never a
+  soundness hazard. Guard: `tests/test_offload_hubs.py`.
 
 ## aio bridge invariants (src/runloom/aio/)
 - Layout: `_base.py` is the foundation (`_go_io`, `_wait_fd`, `_CURRENT_TASKS`);

--- a/src/runloom/__init__.py
+++ b/src/runloom/__init__.py
@@ -202,11 +202,17 @@ def enable_migration(allow_unsafe=False):
     Idempotent."""
     if not migration_available() and not allow_unsafe:
         st = migration_status()
+        # The patches are VERSION-SPECIFIC: the 3.13 alloc-home patch rejects on
+        # 3.14 and the 3.14 exec-home patch rejects on 3.13.  Name the file that
+        # actually applies to the running interpreter -- pointing someone at the
+        # wrong series' patch sends them straight into `patch -F3`, which is how
+        # a silently-wrong interpreter gets built.
+        _tag = "cpython%d%dt" % _sys.version_info[:2]
         missing = ", ".join(
             name for name, have in (
-                ("alloc-home (src/patches/cpython313t-tstate-alloc-home.patch)",
+                ("alloc-home (src/patches/%s-tstate-alloc-home.patch)" % _tag,
                  st["alloc_home"]),
-                ("exec-home (src/patches/cpython314t-tstate-exec-home.patch)",
+                ("exec-home (src/patches/%s-tstate-exec-home.patch)" % _tag,
                  st["exec_home"]),
             ) if not have
         )

--- a/src/runloom/aio/__init__.py
+++ b/src/runloom/aio/__init__.py
@@ -1,5 +1,18 @@
 """runloom.aio -- async/await on the runloom scheduler.
 
+COMPATIBILITY LAYER -- SINGLE-THREADED BY DESIGN.  This bridge runs on the
+per-thread (single-hub) scheduler, NOT the M:N hub pool: each event loop drives
+`runloom_c.run()`, which drains the CALLING thread's own scheduler, so every
+coroutine of a given loop runs on that one thread.  It does NOT spread
+coroutines across hubs, and it does NOT benefit from cross-hub migration -- that
+is deliberate, not a missing feature.  asyncio's contract is thread-affine
+(callbacks fire on the loop thread, signal handlers only on the main thread,
+`run_coroutine_threadsafe` marshals across threads, and a great deal of code
+checks `threading.current_thread()`); a hub runs on its own OS thread, so
+hosting a loop on one would relocate where user code executes and break that
+contract.  For real M:N parallelism use `runloom.fiber()` / `runloom_c.mn_*`
+directly; use this layer when you need drop-in asyncio behaviour.
+
 Approach: each asyncio.Task gets its own runloom fiber.  The fiber
 drives `coro.send()` itself; when the coro yields a pending Future,
 the fiber parks via a 1-buffered channel and resumes when the

--- a/src/runloom_c/mn_sched.c
+++ b/src/runloom_c/mn_sched.c
@@ -284,6 +284,12 @@ typedef struct runloom_hub {
      * hang every adversarial design-review found).  Foreign/cooperative wakes
      * already break the wait via hub_submit's Dekker eventfd kick. */
     volatile int         idle_parked;
+    /* How many global-runq entries are pinned to THIS hub (G.pin(N)).  Only
+     * this hub may take them, so the idle scan must count them for this hub and
+     * for nobody else -- see runloom_mn_any_stealable_work.  Zero in every
+     * production run (nothing pins), and the hub array is PyMem_Calloc'd, so it
+     * needs no per-session reset. */
+    volatile long        runq_pinned_n;
 } runloom_hub_t;
 
 /* B4/R6: enforce that every hub array element starts on its own cache line, so
@@ -461,6 +467,7 @@ static int runloom_hub_tstate_lock_inited = 0;
  * parked hub when it publishes a migratable woken g; the definition lives in
  * mn_sched_hub_main.c.inc (it needs the hub array + per-hub kick helpers). */
 static void runloom_mn_wakep_one(void);
+static void runloom_mn_wakep_pinned(int hub_id);
 
 #include "mn_sched_runq.c.inc"
 #include "mn_sched_hub_resume_preempt.c.inc"

--- a/src/runloom_c/mn_sched.h
+++ b/src/runloom_c/mn_sched.h
@@ -111,6 +111,26 @@ PyObject *runloom_mn_fiber(PyObject *callable, size_t stack_size);
  * feature off). */
 PyObject *runloom_mn_offload_fiber(PyObject *callable, size_t stack_size);
 int runloom_mn_offload_hub_count(void);
+/* Place the fiber on hub `hub_id`, drained to that hub's local FIFO rather than
+ * its stealable deque.  hub_id < 0 is runloom_mn_fiber; out of range raises
+ * ValueError.  Alone among spawn paths it may name a reserved offload hub, so a
+ * test can force general work onto one; on a busy one the fiber strands behind
+ * the blocking call.
+ *
+ * A pinned fiber is NOT stealable: it runs only when its hub does, so it starves
+ * if that hub blocks and no neighbour can rescue it.  That is why this is a
+ * determinism knob for tests and not an affinity feature. */
+PyObject *runloom_mn_fiber_pinned(PyObject *callable, size_t stack_size,
+                                  int hub_id);
+
+/* Confine `g`'s resumes to hub `hub_id` (<0 clears).  Returns 0, or -1 with a
+ * Python error set.  Exposed as G.pin(hub).  A cross-hub target is only sound
+ * under a migration mode, so elsewhere it raises RuntimeError rather than being
+ * silently inert; pinning to its own hub is always legal, and is how a test
+ * asserts a fiber did NOT move.  Same starvation caveat as
+ * runloom_mn_fiber_pinned above. */
+int runloom_mn_pin_for_wake(runloom_g_t *g, int hub_id);
+
 /* Like runloom_mn_fiber but `size` is a grow-down LEARNED size: spawn it down the
  * deferred (lazy) stack-alloc path so a tight front-load loop doesn't cold-mmap a
  * guarded stack per spawn -- the alloc lands on the consumer hub where the pool

--- a/src/runloom_c/mn_sched_hub_main.c.inc
+++ b/src/runloom_c/mn_sched_hub_main.c.inc
@@ -126,6 +126,19 @@ static void runloom_mn_world_yield_if_monopolizing(runloom_hub_t *h)
 #if PY_VERSION_HEX >= 0x030D0000
     int i;
     if (__atomic_load_n(&h->stopping, __ATOMIC_ACQUIRE)) return;
+    /* Exclusion 4, the h side.  The sibling scan below is already bounded by
+     * runloom_general_hub_count(), so an offload hub is never seen AS a
+     * monopolising sibling.  This stops one being the SCANNER.
+     *
+     * It used to be unreachable by accident: an offload hub with queued work
+     * had it on the deque, so the size check below returned.  Pinning offload
+     * spawns moved that work to the ready ring, leaving only the "exactly one
+     * ready" test between an offload hub and a 100us PyEval_SaveThread pause --
+     * on the very hub whose whole job is to get into a blocking call promptly.
+     * No harness has hit that window (a 200x RUNLOOM_WORLD_YIELD_NS shows no
+     * signal), so this guards a structural weakening rather than a measured
+     * regression -- but the property should not rest on a queue choice. */
+    if (runloom_hub_is_offload(h->id)) return;
     /* Sole runnable g: exactly one in the ready ring and the own deque empty.
      * Relaxed loads (as documented above): own-thread here, but the indices are
      * relaxed-atomic for the cross-thread census -- keep every reader consistent. */

--- a/src/runloom_c/mn_sched_hub_main.c.inc
+++ b/src/runloom_c/mn_sched_hub_main.c.inc
@@ -679,7 +679,8 @@ static RUNLOOM_THREAD_RET runloom_hub_main(void *arg)
                      * is unperturbed.  One event per woken g; coalesced by the driver. */
                     runloom_mnwake_trace_event("HUB_DRAIN", (unsigned long)(uintptr_t)sub, 0);
                     runloom_sched_ready_push(&h->sched, sub);
-                } else if (sub->pin_hub1 == h->id + 1) {
+                } else if (__atomic_load_n(&sub->pin_hub1,
+                                          __ATOMIC_ACQUIRE) == h->id + 1) {
                     /* A g pinned to THIS hub goes to the local FIFO, like the
                      * deque-full fallback below -- the deque is what stealing
                      * takes.  Matching this hub exactly, not merely "pinned",

--- a/src/runloom_c/mn_sched_hub_main.c.inc
+++ b/src/runloom_c/mn_sched_hub_main.c.inc
@@ -648,6 +648,14 @@ static RUNLOOM_THREAD_RET runloom_hub_main(void *arg)
                      * is unperturbed.  One event per woken g; coalesced by the driver. */
                     runloom_mnwake_trace_event("HUB_DRAIN", (unsigned long)(uintptr_t)sub, 0);
                     runloom_sched_ready_push(&h->sched, sub);
+                } else if (sub->pin_hub1 == h->id + 1) {
+                    /* A g pinned to THIS hub goes to the local FIFO, like the
+                     * deque-full fallback below -- the deque is what stealing
+                     * takes.  Matching this hub exactly, not merely "pinned",
+                     * so a g pinned elsewhere falls through to the deque and
+                     * stays stealable rather than stranding on the wrong hub's
+                     * un-stealable FIFO. */
+                    runloom_sched_ready_push(&h->sched, sub);
                 } else if (runloom_cldeque_push(&h->deque, sub) != 0) {
                     RUNLOOM_COVER_HIT(RUNLOOM_COV_DEQUE_FULL_FALLBACK);
                     /* Deque full (>RUNLOOM_CLDEQUE_CAP=4096 fresh gs on this
@@ -789,7 +797,7 @@ static RUNLOOM_THREAD_RET runloom_hub_main(void *arg)
              * stalled hub's woken work is recovered promptly.  from_runq tells
              * the resume block to claim the g (QUEUED->RUNNING) and to drop the
              * entry's queue ref when the resume ends. */
-            g = runloom_mn_global_runq_pull();
+            g = runloom_mn_global_runq_pull(h->id);
             if (g != NULL) {
                 RUNLOOM_COVER_HIT(RUNLOOM_COV_GLOBAL_RUNQ_PULL);
                 from_runq = 1;

--- a/src/runloom_c/mn_sched_hub_main.c.inc
+++ b/src/runloom_c/mn_sched_hub_main.c.inc
@@ -250,16 +250,46 @@ static volatile int runloom_mn_nidle = 0;   /* # hubs with idle_parked=1 (hint) 
 /* True iff some hub holds stealable surplus a steal would find RIGHT NOW: the
  * global runq is non-empty, or some deque has >1 g (one for its owner to run, at
  * least one to steal).  Cheap, lock-free; scanned only at park-decision time. */
-static int runloom_mn_any_stealable_work(void)
+static int runloom_mn_any_stealable_work(const runloom_hub_t *self)
 {
     int i;
-    if (__atomic_load_n(&runloom_global_runq_len, __ATOMIC_ACQUIRE) > 0) return 1;
+    /* UNPINNED entries only: an entry pinned to another hub is not work THIS
+     * hub may take, and counting it kept the hub awake to poll for something it
+     * would walk straight past -- one pinned entry behind a busy hub burned
+     * every other idle hub (measured 6.6s CPU for 2.0s wall at H=8).  Same
+     * reasoning as the general-hub bound below, one line up.  Plus this hub's
+     * OWN pinned entries, which only it can take and which it must not sleep
+     * through.  Both counters equal the totals when nothing is pinned. */
+    if (__atomic_load_n(&runloom_global_runq_unpinned_len, __ATOMIC_ACQUIRE) > 0)
+        return 1;
+    if (self != NULL &&
+        __atomic_load_n(&self->runq_pinned_n, __ATOMIC_ACQUIRE) > 0) return 1;
     /* General hubs only: work sitting on an offload hub is NOT stealable by
      * anyone (exclusion 2), so counting it here would wake general hubs to
      * hunt for work they are forbidden to take. */
     for (i = 0; i < runloom_general_hub_count(); i++)
         if (runloom_cldeque_size(&runloom_hubs[i].deque) > 1) return 1;
     return 0;
+}
+
+/* Kick ONE named hub out of a deep idle wait, if it is registered.  Returns 1
+ * if this call is the CAS winner that un-parked it (the sole nidle decrementer),
+ * 0 if it was not parked or another thread got there first. */
+static int runloom_mn_wakep_kick(runloom_hub_t *h)
+{
+    int expect = 1;
+    if (__atomic_load_n(&h->idle_parked, __ATOMIC_RELAXED) != 1) return 0;
+    if (!__atomic_compare_exchange_n(&h->idle_parked, &expect, 0, 0,
+                                     __ATOMIC_ACQ_REL, __ATOMIC_RELAXED)) return 0;
+    __atomic_sub_fetch(&runloom_mn_nidle, 1, __ATOMIC_ACQ_REL);
+    /* Kick every wait mode (one hub; mirrors runloom_mn_kick_all_hubs). */
+    if (h->loop_wake_fd >= 0)
+        runloom_iouring_loop_wake(h->loop_wake_fd);
+    RUNLOOM_RLOCK(&h->idle_lock, RUNLOOM_RANK_HUB_IDLE);
+    runloom_cond_signal(&h->idle_cond);
+    RUNLOOM_RUNLOCK(&h->idle_lock, RUNLOOM_RANK_HUB_IDLE);
+    runloom_netpoll_wake_pump((void *)h);
+    return 1;
 }
 
 /* Producer side: wake ONE parked hub so it re-scans + steals.  Gated on the
@@ -285,22 +315,23 @@ static void runloom_mn_wakep_one(void)
      * Offload hubs are woken by their own submit path instead
      * (runloom_mn_hub_submit), which is how pinned work reaches them. */
     for (i = 0; i < runloom_general_hub_count(); i++) {
-        runloom_hub_t *h = &runloom_hubs[i];
-        int expect = 1;
-        if (__atomic_load_n(&h->idle_parked, __ATOMIC_RELAXED) != 1) continue;
-        if (__atomic_compare_exchange_n(&h->idle_parked, &expect, 0, 0,
-                                        __ATOMIC_ACQ_REL, __ATOMIC_RELAXED)) {
-            __atomic_sub_fetch(&runloom_mn_nidle, 1, __ATOMIC_ACQ_REL);
-            /* Kick every wait mode (one hub; mirrors runloom_mn_kick_all_hubs). */
-            if (h->loop_wake_fd >= 0)
-                runloom_iouring_loop_wake(h->loop_wake_fd);
-            RUNLOOM_RLOCK(&h->idle_lock, RUNLOOM_RANK_HUB_IDLE);
-            runloom_cond_signal(&h->idle_cond);
-            RUNLOOM_RUNLOCK(&h->idle_lock, RUNLOOM_RANK_HUB_IDLE);
-            runloom_netpoll_wake_pump((void *)h);
+        if (runloom_mn_wakep_kick(&runloom_hubs[i]))
             return;                              /* one wakep per surplus, like Go */
-        }
     }
+}
+
+/* Wake the ONE hub a pinned global-runq entry belongs to.  wakep_one is no use
+ * here: it wakes any general hub, and every hub but this one walks straight past
+ * a pinned entry -- so the entry's own hub could stay deep-parked while another
+ * hub burns a scan.  Bypasses the general-hub bound on purpose: G.pin(N) accepts
+ * any live hub id, and whichever hub owns the entry is the only one that can run
+ * it.  Same backoff gate as wakep_one, so the shipped default pays nothing. */
+static void runloom_mn_wakep_pinned(int hub_id)
+{
+    if (runloom_idle_backoff_cap_ms() <= 1) return;
+    __atomic_thread_fence(__ATOMIC_SEQ_CST);     /* publish BEFORE the idle read */
+    if (hub_id < 0 || hub_id >= runloom_hub_count || runloom_hubs == NULL) return;
+    (void)runloom_mn_wakep_kick(&runloom_hubs[hub_id]);
 }
 
 /* Park side: register this hub as wakep-able, then re-scan (the double-check).
@@ -313,7 +344,7 @@ static int runloom_mn_park_enter(runloom_hub_t *h)
     __atomic_store_n(&h->idle_parked, 1, __ATOMIC_RELEASE);
     __atomic_add_fetch(&runloom_mn_nidle, 1, __ATOMIC_ACQ_REL);
     __atomic_thread_fence(__ATOMIC_SEQ_CST);   /* set-flag BEFORE re-scan */
-    if (runloom_mn_any_stealable_work()) {
+    if (runloom_mn_any_stealable_work(h)) {
         expect = 1;
         if (__atomic_compare_exchange_n(&h->idle_parked, &expect, 0, 0,
                                         __ATOMIC_ACQ_REL, __ATOMIC_RELAXED))

--- a/src/runloom_c/mn_sched_init_fini.c.inc
+++ b/src/runloom_c/mn_sched_init_fini.c.inc
@@ -738,10 +738,14 @@ static int runloom_mn_fiber_core(PyObject *callable, runloom_c_entry_fn c_fn,
             }
         }
     }
+    /* Bumped BEFORE the pin branch: the controlled-replay barrier keys on the
+     * spawn_counter%H map, so a pinned spawn must still consume its index. */
     n = __atomic_fetch_add(&runloom_mn_spawn_counter, 1, __ATOMIC_RELAXED);
     if (force_hub >= 0 && force_hub < runloom_hub_count) {
-        /* Pinned (offload).  Skips the general-hub modulus entirely -- this is
-         * the ONLY way a g may legitimately land on an offload hub. */
+        /* Pinned: skips the general-hub modulus, so this is the only way a g
+         * lands on an offload hub.  Beats every placement policy, the
+         * sanitizer lane's randomization included.  Both API boundaries
+         * validate; re-checked anyway rather than index off the end. */
         hub_idx = force_hub;
     } else {
         /* EXCLUSION 1 of 3: general spawns are placed over general hubs only.
@@ -801,6 +805,11 @@ static int runloom_mn_fiber_core(PyObject *callable, runloom_c_entry_fn c_fn,
     g->owner = &h->sched;   /* owning hub's sched -- groups fibers in the dump */
     __atomic_store_n(&g->id, runloom_next_goid(), __ATOMIC_RELAXED);
     g->park_fd = -1;
+    /* Record the pin (+1 encoded, see runloom_sched.h) so the drain routes this
+     * g to hub_idx's LOCAL FIFO, not its stealable deque -- placement alone is
+     * not enough.  Both force_hub callers need it: the mn_fiber(hub=) knob, and
+     * offload, whose fiber must not be dragged onto a general hub. */
+    if (force_hub >= 0) g->pin_hub1 = hub_idx + 1;
     /* Clamp an explicit per-spawn size to [MIN, MAX], exactly like the
      * single-thread go() path (runloom_sched_spawn_sized): "the explicit size
      * wins" means it overrides the autosizer, not that it can exceed the 8 MiB
@@ -956,6 +965,40 @@ PyObject *runloom_mn_offload_fiber(PyObject *callable, size_t stack_size)
     slot = (unsigned long)__atomic_fetch_add(&runloom_mn_offload_rr, 1, __ATOMIC_RELAXED);
     hub  = runloom_general_hub_count() + (int)(slot % (unsigned long)k);
     if (runloom_mn_fiber_core(callable, NULL, NULL, stack_size, -1, 0, hub) < 0) {
+        return NULL;
+    }
+    Py_RETURN_NONE;
+}
+
+/* Spawn `callable` on hub `hub_id` and keep it there (see mn_sched.h).
+ * hub_id < 0 is plain runloom_mn_fiber. */
+PyObject *runloom_mn_fiber_pinned(PyObject *callable, size_t stack_size,
+                                  int hub_id)
+{
+    if (hub_id >= 0) {
+        /* Validate against the LIVE hub count, or the fiber lands elsewhere
+         * and the test asserts nothing.  The bound is runloom_hub_count,
+         * DELIBERATELY including the reserved offload hubs -- a knowing
+         * exception to "no general work ever lands on an offload hub"
+         * (CLAUDE.md), and the only way a test can drive those exclusions from
+         * the inside.  Liveness only: pinned to a BUSY offload hub the fiber
+         * strands.  Nothing migrates, so never corruption. */
+        if (runloom_hubs == NULL || runloom_hub_count <= 0) {
+            PyErr_SetString(PyExc_RuntimeError,
+                            "mn_fiber(hub=): the M:N runtime is not running");
+            return NULL;
+        }
+        if (hub_id >= runloom_hub_count) {
+            PyErr_Format(PyExc_ValueError,
+                         "mn_fiber(hub=%d): only %d hub%s running (0..%d)",
+                         hub_id, runloom_hub_count,
+                         runloom_hub_count == 1 ? " is" : "s are",
+                         runloom_hub_count - 1);
+            return NULL;
+        }
+    }
+    if (runloom_mn_fiber_core(callable, NULL, NULL, stack_size, -1, 0,
+                              hub_id) < 0) {
         return NULL;
     }
     Py_RETURN_NONE;

--- a/src/runloom_c/mn_sched_init_fini.c.inc
+++ b/src/runloom_c/mn_sched_init_fini.c.inc
@@ -509,6 +509,12 @@ void runloom_mn_fini(void)
         runloom_g_t *g = runloom_global_runq_head;
         runloom_global_runq_head = runloom_global_runq_tail = NULL;
         __atomic_store_n(&runloom_global_runq_len, 0, __ATOMIC_RELEASE);
+        /* Must be zeroed with its sibling: unlike the per-hub runq_pinned_n
+         * (a runloom_hub_t field PyMem_Calloc zeroes per session) this is a
+         * file-scope static, so a leftover queued entry at teardown would
+         * carry a phantom count into the NEXT session and keep every hub
+         * from sleeping. */
+        __atomic_store_n(&runloom_global_runq_unpinned_len, 0, __ATOMIC_RELEASE);
         while (g != NULL) {
             runloom_g_t *next = g->next;
             g->next = NULL;
@@ -650,6 +656,7 @@ void runloom_mn_reset_after_fork(void)
     runloom_mutex_init(&runloom_global_runq_lock);   /* may be inherited held */
     runloom_global_runq_head = runloom_global_runq_tail = NULL;
     __atomic_store_n(&runloom_global_runq_len, 0, __ATOMIC_RELAXED);
+    __atomic_store_n(&runloom_global_runq_unpinned_len, 0, __ATOMIC_RELAXED);
     runloom_tls_hub = NULL;        /* the surviving thread is no longer a hub */
     runloom_tls_current_g = NULL;
     runloom_coro_prewarm_reset_after_fork();   /* daemon thread didn't survive */
@@ -807,9 +814,17 @@ static int runloom_mn_fiber_core(PyObject *callable, runloom_c_entry_fn c_fn,
     g->park_fd = -1;
     /* Record the pin (+1 encoded, see runloom_sched.h) so the drain routes this
      * g to hub_idx's LOCAL FIFO, not its stealable deque -- placement alone is
-     * not enough.  Both force_hub callers need it: the mn_fiber(hub=) knob, and
-     * offload, whose fiber must not be dragged onto a general hub. */
-    if (force_hub >= 0) g->pin_hub1 = hub_idx + 1;
+     * not enough, since the deque is what stealing takes.
+     *
+     * This deliberately covers BOTH force_hub callers, for two different
+     * reasons.  For mn_fiber(hub=) it is the whole contract.  For offload it is
+     * not merely inherited: the steal exclusions already keep an offload hub
+     * from being a thief or a victim, but under a migration mode a woken
+     * offload fiber goes to the GLOBAL RUNQ, where without a pin any general
+     * hub may pull it -- dragging a blocking call onto a general hub, which is
+     * exclusion 2 violated from the other side.  The pin is what closes that. */
+    if (force_hub >= 0)
+        __atomic_store_n(&g->pin_hub1, hub_idx + 1, __ATOMIC_RELEASE);
     /* Clamp an explicit per-spawn size to [MIN, MAX], exactly like the
      * single-thread go() path (runloom_sched_spawn_sized): "the explicit size
      * wins" means it overrides the autosizer, not that it can exceed the 8 MiB

--- a/src/runloom_c/mn_sched_mn_api.c.inc
+++ b/src/runloom_c/mn_sched_mn_api.c.inc
@@ -261,6 +261,61 @@ static void runloom_mn_hub_submit(runloom_hub_t *h, runloom_g_t *g)
         runloom_mnwake_trace_event("SIGNAL", (unsigned long)(uintptr_t)g, 0);
 }
 
+/* Confine g's next (and every later) wake to hub `hub_id`.  See the contract in
+ * mn_sched.h and the pin_hub1 field comment in runloom_sched.h. */
+int runloom_mn_pin_for_wake(runloom_g_t *g, int hub_id)
+{
+    void *park_hub;
+    int home;
+    if (g == NULL) {
+        PyErr_SetString(PyExc_RuntimeError, "pin(): dead fiber handle");
+        return -1;
+    }
+    if (hub_id < 0) {                    /* clear the pin */
+        __atomic_store_n(&g->pin_hub1, 0, __ATOMIC_RELEASE);
+        return 0;
+    }
+    if (runloom_hubs == NULL || runloom_hub_count <= 0) {
+        PyErr_SetString(PyExc_RuntimeError,
+                        "pin(): the M:N runtime is not running");
+        return -1;
+    }
+    if (hub_id >= runloom_hub_count) {
+        PyErr_Format(PyExc_ValueError,
+                     "pin(%d): only %d hub%s running (0..%d)",
+                     hub_id, runloom_hub_count,
+                     runloom_hub_count == 1 ? " is" : "s are",
+                     runloom_hub_count - 1);
+        return -1;
+    }
+    /* REFUSE a cross-hub target in the default scheduler -- not dangerous,
+     * INERT: wake_g routes through hub_submit(park_hub) and never reads
+     * pin_hub1, so a test that asked for hub 3 and got hub 1 would PASS while
+     * testing nothing.  The g's own home hub stays legal (that is how a test
+     * asserts a fiber did NOT move); "home" is the park hub, or the running hub
+     * before the first park, which is the self-pin case. */
+    park_hub = (void *)__atomic_load_n(&g->park_hub, __ATOMIC_ACQUIRE);
+    home = runloom_mn_hub_id_of(park_hub);
+    if (home < 0 && g == runloom_tls_current_g && runloom_tls_hub != NULL)
+        home = runloom_tls_hub->id;
+    if (!runloom_use_global_runq() && home != hub_id) {
+        PyErr_Format(PyExc_RuntimeError,
+            "pin(%d): the default scheduler cannot resume a fiber on a hub "
+            "other than its own (%d) -- a woken fiber is hub-pinned by design, "
+            "so this pin would be silently ignored rather than honoured.  Start "
+            "the runtime with runloom.enable_migration() on an interpreter "
+            "carrying both CPython patches (see runloom.migration_status()) to "
+            "target another hub.",
+            hub_id, home);
+        return -1;
+    }
+    /* RELEASE pairs with the runq puller's read under the runq lock: the pin
+     * must be visible to whichever hub inspects the entry, and this store
+     * happens-before the wake that enqueues it. */
+    __atomic_store_n(&g->pin_hub1, hub_id + 1, __ATOMIC_RELEASE);
+    return 0;
+}
+
 void runloom_mn_wake_g(void *hub_opaque, runloom_g_t *g)
 {
     if (hub_opaque == NULL) {

--- a/src/runloom_c/mn_sched_mn_api.c.inc
+++ b/src/runloom_c/mn_sched_mn_api.c.inc
@@ -272,7 +272,7 @@ int runloom_mn_pin_for_wake(runloom_g_t *g, int hub_id)
         return -1;
     }
     if (hub_id < 0) {                    /* clear the pin */
-        __atomic_store_n(&g->pin_hub1, 0, __ATOMIC_RELEASE);
+        runloom_mn_global_runq_repin(g, 0);
         return 0;
     }
     if (runloom_hubs == NULL || runloom_hub_count <= 0) {
@@ -312,7 +312,7 @@ int runloom_mn_pin_for_wake(runloom_g_t *g, int hub_id)
     /* RELEASE pairs with the runq puller's read under the runq lock: the pin
      * must be visible to whichever hub inspects the entry, and this store
      * happens-before the wake that enqueues it. */
-    __atomic_store_n(&g->pin_hub1, hub_id + 1, __ATOMIC_RELEASE);
+    runloom_mn_global_runq_repin(g, hub_id + 1);
     return 0;
 }
 

--- a/src/runloom_c/mn_sched_runq.c.inc
+++ b/src/runloom_c/mn_sched_runq.c.inc
@@ -159,9 +159,12 @@ static void runloom_mn_global_runq_push(runloom_g_t *g)
  *
  * Pinned entries (see runloom_sched.h pin_hub1) are walked past on a
  * FIRST-MATCH scan rather than handed to whoever asked first, which is what
- * makes the resume hub assertable instead of statistical.  Nothing is pinned in
- * production, so the head matches on the first iteration.  A pinned entry whose
- * hub never idles waits indefinitely and no other hub rescues it. */
+ * makes the resume hub assertable instead of statistical.  A pinned entry whose
+ * hub never idles waits indefinitely and no other hub rescues it.
+ *
+ * NOT test-only: offload fibers are pinned too (see runloom_mn_fiber_core), so
+ * with RUNLOOM_OFFLOAD_HUBS set the walk runs in production.  It still matches
+ * the head on the first iteration whenever the queue holds anything unpinned. */
 static runloom_g_t *runloom_mn_global_runq_pull(int hub_id)
 {
     runloom_g_t *g, *prev;
@@ -176,7 +179,12 @@ static runloom_g_t *runloom_mn_global_runq_pull(int hub_id)
     RUNLOOM_RLOCK(&runloom_global_runq_lock, RUNLOOM_RANK_GLOBAL_RUNQ);
     prev = NULL;
     g = runloom_global_runq_head;
-    while (g != NULL && g->pin_hub1 != 0 && g->pin_hub1 != want) {
+    while (g != NULL) {
+        /* ONE load: two reads could see different values if a store landed
+         * between them.  Stores are under this lock (repin) or pre-publication
+         * (spawn), so this is consistency hygiene rather than a live race. */
+        int p1 = __atomic_load_n(&g->pin_hub1, __ATOMIC_ACQUIRE);
+        if (p1 == 0 || p1 == want) break;
         prev = g;
         g = g->next;
     }
@@ -203,6 +211,49 @@ static runloom_g_t *runloom_mn_global_runq_pull(int hub_id)
     }
     RUNLOOM_RUNLOCK(&runloom_global_runq_lock, RUNLOOM_RANK_GLOBAL_RUNQ);
     return g;
+}
+
+/* Store g->pin_hub1 while keeping the run-queue accounting consistent.
+ *
+ * push and pull classify an entry by pin_hub1 UNDER THIS LOCK.  A bare store
+ * from pin() on a g that is already queued therefore makes pull decrement a
+ * different counter than push incremented, and the drift never heals: a stuck
+ * runq_pinned_n stops that hub ever sleeping (measured 0.22 cpu/wall in a fully
+ * idle tail), a stuck unpinned_len does the same to every hub, and a negative
+ * one can make hubs sleep through work they could take.  Walking the queue is
+ * O(n), but only pin() reaches here and the queue is empty in the common case. */
+static void runloom_mn_global_runq_repin(runloom_g_t *g, int new_pin1)
+{
+    runloom_g_t *it;
+    int queued = 0, old_pin1;
+    RUNLOOM_RLOCK(&runloom_global_runq_lock, RUNLOOM_RANK_GLOBAL_RUNQ);
+    old_pin1 = __atomic_load_n(&g->pin_hub1, __ATOMIC_ACQUIRE);
+    for (it = runloom_global_runq_head; it != NULL; it = it->next) {
+        if (it == g) { queued = 1; break; }
+    }
+    if (queued && old_pin1 != new_pin1 && runloom_hubs != NULL) {
+        if (old_pin1 == 0) {
+            __atomic_sub_fetch(&runloom_global_runq_unpinned_len, 1, __ATOMIC_RELAXED);
+        } else if (old_pin1 - 1 < runloom_hub_count) {
+            __atomic_sub_fetch(&runloom_hubs[old_pin1 - 1].runq_pinned_n, 1,
+                               __ATOMIC_RELAXED);
+        }
+        if (new_pin1 == 0) {
+            __atomic_add_fetch(&runloom_global_runq_unpinned_len, 1, __ATOMIC_RELAXED);
+        } else if (new_pin1 - 1 < runloom_hub_count) {
+            __atomic_add_fetch(&runloom_hubs[new_pin1 - 1].runq_pinned_n, 1,
+                               __ATOMIC_RELAXED);
+        }
+    }
+    __atomic_store_n(&g->pin_hub1, new_pin1, __ATOMIC_RELEASE);
+    RUNLOOM_RUNLOCK(&runloom_global_runq_lock, RUNLOOM_RANK_GLOBAL_RUNQ);
+    /* Outside the runq lock (wakep takes hub idle_lock -- do not invert ranks).
+     * A re-pinned queued entry changes WHICH hub may take it, so kick the new
+     * owner: it may be deep-parked, and after the re-pin nobody else will. */
+    if (queued) {
+        if (new_pin1 != 0) runloom_mn_wakep_pinned(new_pin1 - 1);
+        else               runloom_mn_wakep_one();
+    }
 }
 
 /* RUNLOOM_PER_G_TSTATE (default OFF, experimental, GATED): give each fiber its

--- a/src/runloom_c/mn_sched_runq.c.inc
+++ b/src/runloom_c/mn_sched_runq.c.inc
@@ -134,12 +134,20 @@ static void runloom_mn_global_runq_push(runloom_g_t *g)
     runloom_mn_wakep_one();
 }
 
-/* Pop one g from the global run-queue head (NULL if empty).  No per-hub
- * pending rebalance (see header: only the sum matters, and the mutex
- * release/acquire already orders the g's writes for the puller). */
-static runloom_g_t *runloom_mn_global_runq_pull(void)
+/* Pop one g for hub `hub_id` from the global run-queue (NULL if it holds
+ * nothing this hub may run).  No per-hub pending rebalance (see header: only
+ * the sum matters, and the mutex release/acquire already orders the g's writes
+ * for the puller).
+ *
+ * Pinned entries (see runloom_sched.h pin_hub1) are walked past on a
+ * FIRST-MATCH scan rather than handed to whoever asked first, which is what
+ * makes the resume hub assertable instead of statistical.  Nothing is pinned in
+ * production, so the head matches on the first iteration.  A pinned entry whose
+ * hub never idles waits indefinitely and no other hub rescues it. */
+static runloom_g_t *runloom_mn_global_runq_pull(int hub_id)
 {
-    runloom_g_t *g;
+    runloom_g_t *g, *prev;
+    const int want = hub_id + 1;   /* +1 encoding; hub_id<0 -> match unpinned only */
     /* Lock-free fast-out: the queue is empty in the common case (default
      * mode never touches it; per-g-tstate only when a wake is in flight),
      * so skip the mutex when there is clearly nothing to take.  A racing
@@ -148,12 +156,19 @@ static runloom_g_t *runloom_mn_global_runq_pull(void)
         return NULL;
     }
     RUNLOOM_RLOCK(&runloom_global_runq_lock, RUNLOOM_RANK_GLOBAL_RUNQ);
+    prev = NULL;
     g = runloom_global_runq_head;
+    while (g != NULL && g->pin_hub1 != 0 && g->pin_hub1 != want) {
+        prev = g;
+        g = g->next;
+    }
     if (g != NULL) {
-        runloom_global_runq_head = g->next;
-        if (runloom_global_runq_head == NULL) {
-            runloom_global_runq_tail = NULL;
-        }
+        /* Unlink g from wherever the walk stopped.  Read g->next for the tail
+         * fixup BEFORE clearing it -- clearing first would strand the tail
+         * pointer at a node that is no longer last. */
+        if (prev == NULL) runloom_global_runq_head = g->next;
+        else              prev->next = g->next;
+        if (g->next == NULL) runloom_global_runq_tail = prev;
         g->next = NULL;
         __atomic_sub_fetch(&runloom_global_runq_len, 1, __ATOMIC_RELAXED);
     }

--- a/src/runloom_c/mn_sched_runq.c.inc
+++ b/src/runloom_c/mn_sched_runq.c.inc
@@ -107,6 +107,12 @@ static runloom_mutex_t  runloom_global_runq_lock = RUNLOOM_MUTEX_STATIC_INIT;
 static runloom_g_t     *runloom_global_runq_head = NULL;
 static runloom_g_t     *runloom_global_runq_tail = NULL;
 static volatile long runloom_global_runq_len  = 0;
+/* Of those, how many ANY hub may take (pin_hub1 == 0).  The idle scan keys off
+ * this rather than the total: an entry pinned elsewhere is not stealable work
+ * for the hub asking, and treating it as such stops that hub ever sleeping.
+ * Identical to runloom_global_runq_len whenever nothing is pinned, which is
+ * every production run. */
+static volatile long runloom_global_runq_unpinned_len = 0;
 
 /* Link g onto the tail of the global run-queue.  Each entry holds one queue
  * ref (incref'd by the caller -- wake_g, or the RUNNING_WOKEN release) so it
@@ -115,6 +121,7 @@ static volatile long runloom_global_runq_len  = 0;
  * on this queue at most once -- no re-push, no duplicate. */
 static void runloom_mn_global_runq_push(runloom_g_t *g)
 {
+    int pin1;
     RUNLOOM_RLOCK(&runloom_global_runq_lock, RUNLOOM_RANK_GLOBAL_RUNQ);
     g->next = NULL;
     if (runloom_global_runq_tail != NULL) {
@@ -124,14 +131,25 @@ static void runloom_mn_global_runq_push(runloom_g_t *g)
     }
     runloom_global_runq_tail = g;
     __atomic_add_fetch(&runloom_global_runq_len, 1, __ATOMIC_RELAXED);
+    pin1 = __atomic_load_n(&g->pin_hub1, __ATOMIC_ACQUIRE);
+    if (pin1 == 0) {
+        __atomic_add_fetch(&runloom_global_runq_unpinned_len, 1, __ATOMIC_RELAXED);
+    } else if (pin1 - 1 < runloom_hub_count) {
+        __atomic_add_fetch(&runloom_hubs[pin1 - 1].runq_pinned_n, 1, __ATOMIC_RELAXED);
+    }
     RUNLOOM_RUNLOCK(&runloom_global_runq_lock, RUNLOOM_RANK_GLOBAL_RUNQ);
     RUNLOOM_EVT(RUNLOOM_EVT_G_SUBMIT, g, NULL, 0);
     runloom_g_state_set(g, RUNLOOM_GST_SUBMITTED);
     /* WAKEP: a migratable woken g any idle hub may run -- kick a deep-parked hub
      * to re-scan + pull it (the global-runq counterpart of deque-surplus wakep).
      * The unlock above is the release publish; wakep_one's SEQ_CST fence orders
-     * it before the idle_parked read, so no parked hub misses this push. */
-    runloom_mn_wakep_one();
+     * it before the idle_parked read, so no parked hub misses this push.
+     *
+     * A PINNED entry must kick its own hub instead: every other hub walks past
+     * it, so a generic wakep would rouse a hub that cannot take the work while
+     * the one that can stays deep-parked. */
+    if (pin1 != 0) runloom_mn_wakep_pinned(pin1 - 1);
+    else           runloom_mn_wakep_one();
 }
 
 /* Pop one g for hub `hub_id` from the global run-queue (NULL if it holds
@@ -171,6 +189,17 @@ static runloom_g_t *runloom_mn_global_runq_pull(int hub_id)
         if (g->next == NULL) runloom_global_runq_tail = prev;
         g->next = NULL;
         __atomic_sub_fetch(&runloom_global_runq_len, 1, __ATOMIC_RELAXED);
+        {   /* Mirror the push-side accounting exactly, or the idle scan drifts
+             * and a hub either spins forever or sleeps through its own work. */
+            int pin1 = __atomic_load_n(&g->pin_hub1, __ATOMIC_ACQUIRE);
+            if (pin1 == 0) {
+                __atomic_sub_fetch(&runloom_global_runq_unpinned_len, 1,
+                                   __ATOMIC_RELAXED);
+            } else if (pin1 - 1 < runloom_hub_count) {
+                __atomic_sub_fetch(&runloom_hubs[pin1 - 1].runq_pinned_n, 1,
+                                   __ATOMIC_RELAXED);
+            }
+        }
     }
     RUNLOOM_RUNLOCK(&runloom_global_runq_lock, RUNLOOM_RANK_GLOBAL_RUNQ);
     return g;

--- a/src/runloom_c/module_g.c.inc
+++ b/src/runloom_c/module_g.c.inc
@@ -80,6 +80,23 @@ static PyObject *RunloomG_pin(RunloomG *self, PyObject *args, PyObject *kw)
             return NULL;
         }
     }
+    /* Same stale-handle hazard RunloomG_wake guards (see its comment): a handle
+     * that outlived its M:N session still holds g->park_hub pointing into the
+     * hub array that mn_fini PyMem_Free'd, and pin_for_wake dereferences it to
+     * learn the g's home hub.  runloom_hubs != NULL does not save us -- a NEW
+     * session makes it non-NULL again while park_hub still points at the freed
+     * one.  Refuse loudly rather than no-op like wake(): a silently-ignored pin
+     * is exactly the "test asserts nothing" failure this knob exists to
+     * prevent.  Only the pinning path derefs; pin(None) is always safe. */
+    if (target >= 0) {
+        void *ph = (void *)__atomic_load_n(&wg->park_hub, __ATOMIC_ACQUIRE);
+        if (ph != NULL && self->born_gen != runloom_mn_generation_get()) {
+            PyErr_SetString(PyExc_RuntimeError,
+                "pin(): this fiber belongs to a torn-down M:N session; its hub "
+                "no longer exists, so the pin cannot be honoured");
+            return NULL;
+        }
+    }
     if (runloom_mn_pin_for_wake(wg, target) < 0) return NULL;
     Py_RETURN_NONE;
 }

--- a/src/runloom_c/module_g.c.inc
+++ b/src/runloom_c/module_g.c.inc
@@ -53,6 +53,37 @@ static PyObject *RunloomG_exception_get(RunloomG *self, void *closure)
     return e;
 }
 
+/* pin(hub): confine this fiber's resumes to `hub`; pin(None) unpins.  Separate
+ * from wake() so a fiber can pin ITSELF before parking --
+ *
+ *     runloom_c.current_g().pin(3); ch.recv()   # resumes on hub 3
+ *
+ * -- letting a plain rendezvous land it where the test says.  Fusing the pin
+ * into wake() would force the waker to hold the handle AND wait for a genuine
+ * park, since an early wake is absorbed by the park_safe/wake_safe handshake
+ * and the fiber then never suspends. */
+static PyObject *RunloomG_pin(RunloomG *self, PyObject *args, PyObject *kw)
+{
+    static char *kwlist[] = {"hub", NULL};
+    PyObject *hubobj;
+    int target = -1;                       /* -1 == clear the pin */
+    runloom_g_t *wg = __atomic_load_n(&self->g, __ATOMIC_ACQUIRE);
+    if (!PyArg_ParseTupleAndKeywords(args, kw, "O", kwlist, &hubobj)) {
+        return NULL;
+    }
+    if (hubobj != Py_None) {
+        target = (int)PyLong_AsLong(hubobj);
+        if (target == -1 && PyErr_Occurred()) return NULL;
+        if (target < 0) {
+            PyErr_SetString(PyExc_ValueError,
+                "pin(): hub id must be >= 0 (pass None to unpin)");
+            return NULL;
+        }
+    }
+    if (runloom_mn_pin_for_wake(wg, target) < 0) return NULL;
+    Py_RETURN_NONE;
+}
+
 /* Wake a fiber parked via runloom_c.park_self() or runloom_c.park().  Safe to
  * call before the park (race-handled inside the wake primitives) and from a
  * foreign OS thread.  ROUTES BY HOW THE g PARKED: a g parked on an M:N hub
@@ -156,6 +187,20 @@ static PyObject *RunloomG_stack(RunloomG *self, PyObject *unused)
     } else if (self->g->snap.valid) {
         state = (runloom_sched_get()->current == self->g) ? "running" : "parked";
         has_snap = 1;
+    } else if (runloom_get_per_g_tstate_mode()) {
+        /* Migration mode has no snap: the per-g tstate carries the suspended
+         * state, so snap.valid is 0 for EVERY fiber and the "fresh" branch
+         * below reported a parked fiber as never-started -- breaking the
+         * obvious way to wait for a fiber to park.  The wake state machine is
+         * authoritative here; has_snap stays 0, as there really is none. */
+        int ws = __atomic_load_n(&self->g->wake_state, __ATOMIC_ACQUIRE);
+        switch (ws) {
+        case RUNLOOM_WS_PARKED:   state = "parked";  break;
+        case RUNLOOM_WS_QUEUED:   state = "queued";  break;   /* woken, not yet resumed */
+        case RUNLOOM_WS_RUNNING:  /* fall through */
+        default:                  state = "running"; break;
+        }
+        has_snap = 0;
     } else {
         state = "fresh";
         has_snap = 0;
@@ -210,17 +255,34 @@ static Py_hash_t RunloomG_hash(PyObject *self)
 }
 
 static PyMethodDef RunloomG_methods[] = {
+    {"pin", (PyCFunction)RunloomG_pin, METH_VARARGS | METH_KEYWORDS,
+     "pin(hub): confine this fiber's next and later resumes to `hub`; "
+     "pin(None) unpins.  A fiber can pin ITSELF before parking -- "
+     "current_g().pin(3) then an ordinary channel recv resumes it on hub 3 -- "
+     "so a placement test needs no handle passed to the waker and nothing to "
+     "poll.  Pinning to a hub other than the fiber's own raises RuntimeError "
+     "unless the runtime was started with migration enabled, since the default "
+     "scheduler would ignore it rather than honour it.\n\n"
+     "A pinned fiber is NOT stealable: it runs only when `hub` does, and "
+     "starves if that hub blocks.  For making placement deterministic in a "
+     "test, not for affinity."},
     {"wake", (PyCFunction)RunloomG_wake, METH_NOARGS,
      "Wake this fiber if parked via park_self().  Safe to call "
-     "before park_self (race-handled)."},
+     "before park_self (race-handled).  Where it resumes is decided by pin(), "
+     "not here."},
     {"cancel_wait_fd", (PyCFunction)RunloomG_cancel_wait_fd, METH_NOARGS,
      "Cancel this fiber if parked in wait_fd: its wait_fd returns the "
      "WAIT_FD_CANCELLED sentinel and it is re-queued.  Returns True if it was "
      "netpoll-parked, else False (use wake() for park_self parkers)."},
     {"stack", (PyCFunction)RunloomG_stack, METH_NOARGS,
      "Return a small introspection dict: "
-     "{'state': 'done'|'running'|'parked'|'fresh', 'has_snap': bool}.  "
-     "Watchdog-safe; cheap to poll for 'where is task X stuck?'."},
+     "{'state': 'done'|'running'|'parked'|'queued'|'fresh', 'has_snap': bool}.  "
+     "Watchdog-safe; cheap to poll for 'where is task X stuck?'.\n\n"
+     "Under migration mode there is no snap to read (the per-g tstate carries "
+     "the suspended state), so the state comes from the wake state machine "
+     "instead: 'parked' and the woken-but-not-yet-resumed 'queued' are exact, "
+     "but a fiber that has not started yet reports 'running' rather than "
+     "'fresh' -- the two are not distinguishable from that field alone."},
     {NULL, NULL, 0, NULL},
 };
 

--- a/src/runloom_c/module_init.c.inc
+++ b/src/runloom_c/module_init.c.inc
@@ -271,10 +271,21 @@ static PyMethodDef module_methods[] = {
      "an explicit value overrides it, so a library can ask for what its own "
      "code needs without requiring its host to set an environment variable."},
     {"mn_fiber",       (PyCFunction)m_mn_fiber, METH_VARARGS | METH_KEYWORDS,
-     "mn_fiber(callable, stack_size=0): spawn a fiber on a round-robin hub.  "
-     "stack_size>0 overrides the hub's small default C-stack (bytes) for a g "
-     "that runs a deep non-yielding C burst.  "
-     "v1 only supports run-to-completion gs (no yield)."},
+     "mn_fiber(callable, stack_size=0, hub=-1): spawn a fiber on a round-robin "
+     "hub.  stack_size>0 overrides the hub's small default C-stack (bytes) for "
+     "a g that runs a deep non-yielding C burst.  "
+     "v1 only supports run-to-completion gs (no yield).\n\n"
+     "hub=N spawns on hub N and keeps it there (local queue, not the stealable "
+     "deque), so no other hub can steal it.  N may name a reserved offload hub "
+     "-- no other spawn path can -- but pinning to a BUSY one strands the fiber "
+     "behind its blocking call.\n\n"
+     "A pinned fiber is NOT stealable: it runs only when hub N does, and "
+     "starves if N blocks.  For making placement deterministic in a test, not "
+     "for affinity."},
+    {"mn_current_hub", m_mn_current_hub, METH_NOARGS,
+     "mn_current_hub() -> int | None.  Dense id of the hub running the calling "
+     "fiber, or None off-hub (single-thread scheduler / foreign OS thread).  "
+     "The read a placement test asserts against."},
     {"fiber_n",        (PyCFunction)m_fiber_n, METH_VARARGS | METH_KEYWORDS,
      "fiber_n(fn, n, stack_size=0): bulk-spawn n fibers all running fn(), "
      "looping the spawn core in C (skips n Python->C dispatches).  fn still "

--- a/src/runloom_c/module_run.c.inc
+++ b/src/runloom_c/module_run.c.inc
@@ -474,9 +474,10 @@ static PyObject *m_mn_init(PyObject *self, PyObject *args, PyObject *kw)
 
 static PyObject *m_mn_fiber(PyObject *self, PyObject *args, PyObject *kw)
 {
-    static char *kwlist[] = {"fn", "stack_size", NULL};
+    static char *kwlist[] = {"fn", "stack_size", "hub", NULL};
     PyObject *callable;
     Py_ssize_t stack_size = 0;
+    int hub = -1;
     (void)self;
     /* mn-sim fence (I3, wake contract #16): a spawn from a FOREIGN OS thread
      * during a seeded run inserts work at a wall-clock-decided placement slot.
@@ -492,15 +493,33 @@ static PyObject *m_mn_fiber(PyObject *self, PyObject *args, PyObject *kw)
             "ordered (MN_SIM_DST_PLAN.md wake contract #16)");
         return NULL;
     }
-    if (!PyArg_ParseTupleAndKeywords(args, kw, "O|n", kwlist,
-                                     &callable, &stack_size)) {
+    if (!PyArg_ParseTupleAndKeywords(args, kw, "O|ni", kwlist,
+                                     &callable, &stack_size, &hub)) {
         return NULL;
     }
     if (!PyCallable_Check(callable)) {
         PyErr_SetString(PyExc_TypeError, "mn_fiber(): callable required");
         return NULL;
     }
+    if (hub >= 0) {
+        return runloom_mn_fiber_pinned(callable,
+                                       stack_size > 0 ? (size_t)stack_size : 0,
+                                       hub);
+    }
     return runloom_mn_fiber(callable, stack_size > 0 ? (size_t)stack_size : 0);
+}
+
+/* mn_current_hub() -> int | None.  The dense id of the hub running the calling
+ * fiber, or None on a non-hub thread (the single-thread scheduler, or any
+ * foreign OS thread).  The read a pinning test asserts against: "I asked for
+ * hub 3; which hub am I actually on?"  Lock-free TLS read. */
+static PyObject *m_mn_current_hub(PyObject *self, PyObject *unused)
+{
+    int id;
+    (void)self; (void)unused;
+    id = runloom_mn_hub_id_of(runloom_mn_current_hub_opaque());
+    if (id < 0) Py_RETURN_NONE;
+    return PyLong_FromLong(id);
 }
 
 /* fiber_n(fn, n, stack_size=0, indexed=False): bulk-spawn n fibers all running

--- a/src/runloom_c/runloom_sched.h
+++ b/src/runloom_c/runloom_sched.h
@@ -405,7 +405,10 @@ struct runloom_g {
      * raw hub id would make every recycled g read as pinned to hub 0.  Spawn
      * honours it by draining to that hub's local FIFO; wake, by letting only
      * that hub pull the g off the global runq.  A pinned g is not stealable, so
-     * it starves if its hub blocks -- nothing sets this unless asked. */
+     * it starves if its hub blocks.  Set by the test knob AND by every offload
+     * spawn, so this is live in production whenever RUNLOOM_OFFLOAD_HUBS is.
+     * Changing it on an already-queued g must go through
+     * runloom_mn_global_runq_repin, which keeps the runq counters consistent. */
     int pin_hub1;
     /* MPSC link for the home sched's cross-thread wake list.  Used
      * only while g is parked via park_safe AND a cross-thread wake

--- a/src/runloom_c/runloom_sched.h
+++ b/src/runloom_c/runloom_sched.h
@@ -399,6 +399,14 @@ struct runloom_g {
      * Set only by runloom_park_generic; a g never park_generic'd leaves it NULL
      * (it is woken by its own parker -- netpoll/chan -- not via this field). */
     void *park_hub;
+    /* The hub this fiber is confined to (mn_fiber(hub=N) / G.pin(N)), PLUS ONE
+     * so 0 == unpinned.  The +1 is load-bearing: slab_alloc zeroes everything
+     * before `state`, and gs are allocated on paths that never see a pin, so a
+     * raw hub id would make every recycled g read as pinned to hub 0.  Spawn
+     * honours it by draining to that hub's local FIFO; wake, by letting only
+     * that hub pull the g off the global runq.  A pinned g is not stealable, so
+     * it starves if its hub blocks -- nothing sets this unless asked. */
+    int pin_hub1;
     /* MPSC link for the home sched's cross-thread wake list.  Used
      * only while g is parked via park_safe AND a cross-thread wake
      * is in flight (between wake_safe's enqueue and drain's

--- a/tests/test_hub_pinning.py
+++ b/tests/test_hub_pinning.py
@@ -162,6 +162,56 @@ def test_pinned_runq_entry_does_not_spin_the_other_hubs():
         % (cpu, wall, cpu / wall))
 
 
+@pytest.mark.skipif(not needs_free_threading(), reason="needs a free-threaded build")
+@pytest.mark.skipif(not runloom.migration_available(),
+                    reason="needs both CPython migration patches (src/patches/)")
+def test_repinning_a_queued_fiber_keeps_the_runq_counters_consistent():
+    """The idle scan counts runq entries by pin, and push/pull classify under the
+    runq lock -- so pin() must not store pin_hub1 behind that lock's back.  Here
+    the fiber is woken while its target hub is busy (so the entry sits queued),
+    then UNPINNED: pull then credits a different counter than push debited, and
+    the drift never heals.  A stuck per-hub count stops that hub ever sleeping.
+
+    Asserted on the IDLE TAIL after everything has finished, where a correct
+    scheduler burns nothing: measured 0.03 healthy vs 0.22 drifted."""
+    HUBS, TARGET, BUSY = 4, 3, 1.5
+
+    def body():
+        ch = rc.Chan(1)
+
+        def victim():
+            g = rc.current_g()
+            g.pin(TARGET)
+            ch.send(g)
+            rc.park()
+
+        def hog():
+            end = time.monotonic() + BUSY
+            while time.monotonic() < end:
+                pass
+
+        rc.mn_fiber(victim, hub=0)
+        rc.mn_fiber(hog, hub=TARGET)
+        g, _ = ch.recv()
+        while g.stack()["state"] != "parked":
+            rc.yield_()
+        g.wake()                 # queued, pinned to the busy TARGET -> no pull yet
+        runloom.sleep(0.3)
+        g.pin(None)              # re-classify WHILE QUEUED
+        runloom.sleep(BUSY + 0.5)
+
+    rc.mn_init(HUBS)
+    rc.mn_fiber(body)
+    rc.mn_run()
+    w0, c0 = time.monotonic(), time.process_time()
+    time.sleep(1.0)              # nothing is runnable; hubs must be asleep
+    wall, cpu = time.monotonic() - w0, time.process_time() - c0
+    rc.mn_fini()
+    assert cpu / wall < 0.10, (
+        "hubs spun in an idle tail: cpu=%.2fs wall=%.2fs (%.2fx) -- runq counters "
+        "drifted when a queued fiber was re-pinned" % (cpu, wall, cpu / wall))
+
+
 if __name__ == "__main__":
     if runloom.migration_available():
         for hub in range(HUBS):

--- a/tests/test_hub_pinning.py
+++ b/tests/test_hub_pinning.py
@@ -1,0 +1,75 @@
+"""Minimal working example: a fiber spawns on hub 0, then resumes where it says.
+
+    mn_fiber(fn, hub=0)   spawn on hub 0 and stay there (no work-stealing)
+    G.pin(N)              confine the next resume to hub N
+
+Placement is otherwise deliberately free, so migration could previously only be
+measured statistically ("~80% of wakes landed elsewhere").  Every destination is
+asserted here, which is what stops this passing by accident: with NO pin this
+workload resumes on hub 0 every time (measured 40/40), so pin(1)/(2)/(3) each
+demand an outcome the unpinned scheduler does not produce, and pin(0) is the
+stayed-put control.  A pin degraded to a no-op fails three of the four.
+
+Run directly:  PYTHON_GIL=0 PYTHONPATH=src python tests/test_hub_pinning.py
+"""
+import os
+
+# Read once at the first mn_init, so it has to be set before the runtime starts.
+os.environ.setdefault("RUNLOOM_MIGRATION", "1")
+
+import pytest
+
+import runloom
+import runloom_c as rc
+
+from adv_util import needs_free_threading
+
+HUBS = 4
+
+
+def spawn_on_0_resume_on(hub):
+    handoff, res = rc.Chan(1), rc.Chan(2)
+
+    def fiber():
+        g = rc.current_g()
+        g.pin(hub)                        # next resume must be on this hub
+        handoff.send(g)
+        res.send(rc.mn_current_hub())     # spawned on hub 0
+        rc.park()
+        res.send(rc.mn_current_hub())     # resumed on `hub`
+
+    def waker():
+        g, _ = handoff.recv()
+        # Wait until it has genuinely suspended.  NOT a correctness guard --
+        # park_safe/wake_safe already absorbs an early wake, and that is the
+        # problem: a fiber that never suspends never migrates, so without this
+        # the moved-hub cases read (0, 0) about 15% of the time.
+        while g.stack()["state"] != "parked":
+            rc.yield_()
+        g.wake()                          # ordinary wake; the pin picked the hub
+
+    rc.mn_init(HUBS)
+    rc.mn_fiber(fiber, hub=0)
+    rc.mn_fiber(waker, hub=1)
+    rc.mn_run()
+    before, _ = res.try_recv()
+    after, _ = res.try_recv()
+    rc.mn_fini()
+    return before, after
+
+
+@pytest.mark.skipif(not needs_free_threading(), reason="needs a free-threaded build")
+@pytest.mark.skipif(not runloom.migration_available(),
+                    reason="needs both CPython migration patches (src/patches/)")
+@pytest.mark.parametrize("hub", range(HUBS))   # 0 stays put; 1-3 must move
+def test_fiber_resumes_on_the_hub_it_pinned_itself_to(hub):
+    assert spawn_on_0_resume_on(hub) == (0, hub)
+
+
+if __name__ == "__main__":
+    if runloom.migration_available():
+        for hub in range(HUBS):
+            print("pin(%d) -> ran on hub %d, then hub %d"
+                  % ((hub,) + spawn_on_0_resume_on(hub)))
+    else:
+        print("skipped --", runloom.migration_status())

--- a/tests/test_hub_pinning.py
+++ b/tests/test_hub_pinning.py
@@ -13,6 +13,7 @@ stayed-put control.  A pin degraded to a no-op fails three of the four.
 Run directly:  PYTHON_GIL=0 PYTHONPATH=src python tests/test_hub_pinning.py
 """
 import os
+import time
 
 # Read once at the first mn_init, so it has to be set before the runtime starts.
 os.environ.setdefault("RUNLOOM_MIGRATION", "1")
@@ -64,6 +65,101 @@ def spawn_on_0_resume_on(hub):
 @pytest.mark.parametrize("hub", range(HUBS))   # 0 stays put; 1-3 must move
 def test_fiber_resumes_on_the_hub_it_pinned_itself_to(hub):
     assert spawn_on_0_resume_on(hub) == (0, hub)
+
+
+@pytest.mark.skipif(not needs_free_threading(), reason="needs a free-threaded build")
+def test_pin_on_a_handle_from_a_torn_down_session_is_refused():
+    """A G handle can outlive its M:N session.  g->park_hub then points into the
+    hub array mn_fini free()d, and pin() dereferences it to find the fiber's home
+    hub -- so without a generation check this reads freed memory and either
+    invents a home hub (observed: 0x41414141 from poisoned heap) or silently
+    ACCEPTS a pin it should reject.  G.wake() has guarded this for the same
+    reason; pin() must too.  Does NOT need the migration patches: the bad
+    dereference is on the default-scheduler path."""
+    esc = []
+
+    def sess1():
+        ch = rc.Chan(1)
+
+        def fiber():
+            g = rc.current_g()
+            esc.append(g)
+            ch.send(g)
+            rc.park()
+
+        def waker():
+            g, _ = ch.recv()
+            while g.stack()["state"] != "parked":
+                rc.yield_()
+            g.wake()
+
+        rc.mn_init(4)
+        rc.mn_fiber(fiber, hub=0)
+        rc.mn_fiber(waker, hub=1)
+        rc.mn_run()
+        rc.mn_fini()
+
+    sess1()
+    junk = [bytearray(b"\x41" * 8192) for _ in range(2000)]   # poison the freed block
+    rc.mn_init(1)
+    rc.mn_fiber(lambda: None)
+    rc.mn_run()
+    try:
+        with pytest.raises(RuntimeError, match="torn-down"):
+            esc[0].pin(0)
+    finally:
+        rc.mn_fini()
+        del junk
+
+
+@pytest.mark.skipif(not needs_free_threading(), reason="needs a free-threaded build")
+@pytest.mark.skipif(not runloom.migration_available(),
+                    reason="needs both CPython migration patches (src/patches/)")
+def test_pinned_runq_entry_does_not_spin_the_other_hubs():
+    """A pinned global-runq entry is invisible work to every hub but its target.
+    The idle scan used to count it as stealable, so each idle hub refused to
+    sleep, polled, walked past the entry and re-looped -- one pinned fiber behind
+    a busy hub burned every other hub (measured 6.6s CPU for 2.0s wall at H=8,
+    ~0.75 core each).  Idle backoff is ON by default, so this was the shipped
+    path.  process_time() is per-process, so a parallel suite does not skew it."""
+    HUBS, BUSY = 8, 1.0
+    TARGET = 3
+
+    def body():
+        ch = rc.Chan(1)
+
+        def sleeper():
+            g = rc.current_g()
+            g.pin(TARGET)
+            ch.send(g)
+            rc.park()
+
+        def hog():
+            end = time.monotonic() + BUSY
+            while time.monotonic() < end:
+                pass
+
+        def waker():
+            g, _ = ch.recv()
+            while g.stack()["state"] != "parked":
+                rc.yield_()
+            g.wake()
+
+        rc.mn_init(HUBS)
+        rc.mn_fiber(sleeper, hub=0)
+        rc.mn_fiber(hog, hub=TARGET)
+        rc.mn_fiber(waker, hub=1)
+        rc.mn_run()
+        rc.mn_fini()
+
+    w0, c0 = time.monotonic(), time.process_time()
+    body()
+    wall, cpu = time.monotonic() - w0, time.process_time() - c0
+    # One hub is legitimately burning a core for BUSY.  Broken measured 3.3x;
+    # fixed measures ~1.0x.  2.0 leaves generous headroom either side.
+    assert cpu / wall < 2.0, (
+        "idle hubs spun on a pinned runq entry: cpu=%.2fs wall=%.2fs (%.1fx)"
+        % (cpu, wall, cpu / wall))
 
 
 if __name__ == "__main__":

--- a/tests/test_offload_hubs.py
+++ b/tests/test_offload_hubs.py
@@ -106,6 +106,59 @@ def test_general_fibers_never_land_on_a_blocked_offload_hub():
     assert elapsed < BLOCK + 1.0
 
 
+def test_mn_fiber_hub_may_target_an_offload_hub_on_purpose():
+    """The one sanctioned breach of the exclusion above.
+
+    Automatic placement is bounded by runloom_general_hub_count() and cannot
+    name a reserved hub even by accident; mn_fiber(hub=N) can, because the
+    caller spelled N out.  Nothing else reaches the tail of runloom_hubs[] --
+    offload_fiber() only round-robins -- so without this the exclusions could
+    only be tested by inference from timing.
+
+    Uses an IDLE offload hub.  On a busy one the fiber would strand behind the
+    blocking call: the documented price of asking, and exactly what the test
+    above proves does NOT happen to ordinary spawns."""
+    K, N_GEN = 2, 4
+    seen = {}
+
+    def body():
+        total = rc.mn_hub_count()
+        gen = total - rc.offload_hub_count()
+        target = total - 1                    # the last RESERVED offload hub
+        done = rc.Chan(1)
+
+        def on_offload():
+            done.send(rc.mn_current_hub())
+
+        rc.mn_fiber(on_offload, hub=target)
+        ran_on, _ = done.recv()
+        seen.update(total=total, gen=gen, target=target, ran_on=ran_on)
+
+    runloom.run(N_GEN, body, offload_hubs=K)
+
+    assert seen["total"] == N_GEN + K
+    assert seen["gen"] == N_GEN
+    # The point of the test evaporates if `target` is not actually reserved.
+    assert seen["target"] >= seen["gen"], (
+        "hub %d is a general hub -- this asserts nothing about offload hubs"
+        % seen["target"])
+    assert seen["ran_on"] == seen["target"], (
+        "pinned to offload hub %d but ran on %d" % (seen["target"], seen["ran_on"]))
+
+
+def test_mn_fiber_hub_still_rejects_a_hub_that_does_not_exist():
+    """Widening the bound to admit offload hubs must not widen it past the end
+    of runloom_hubs[].  An accepted out-of-range index would place the fiber
+    elsewhere and make every placement assert vacuous."""
+    def body():
+        with pytest.raises(ValueError):
+            rc.mn_fiber(lambda: None, hub=rc.mn_hub_count())
+        with pytest.raises(ValueError):
+            rc.mn_fiber(lambda: None, hub=rc.mn_hub_count() + 99)
+
+    runloom.run(2, body, offload_hubs=1)
+
+
 def test_general_hubs_progress_while_every_offload_hub_blocks():
     """What the thread pool used to buy, now bought with the scheduler."""
     K = 2


### PR DESCRIPTION
Placement in runloom is deliberately free — a fresh fiber sits on a stealable Chase-Lev deque, and under migration a woken fiber goes to the process-global run-queue and is resumed by whichever hub drains it first. Both are right for production, and both make migration untestable except statistically: the existing proof can only report *"~80% of wakes landed on some other hub"*, which cannot distinguish "migration works" from "migration works most of the time".

This adds the smallest set of knobs that removes exactly that freedom, and nothing else.

| | |
|---|---|
| `mn_fiber(fn, hub=N)` | place the fresh fiber on hub N **and** drain it to that hub's local FIFO instead of its stealable deque |
| `G.pin(N)` | confine a fiber's resumes to hub N, enforced on the consumer side of the global run-queue |
| `mn_current_hub()` | which hub is running me — what a placement test asserts against |

Placement alone is not enough: with the fiber left on the deque, 35 of 200 pinned spawns ran on the wrong hub. And without the run-queue filter the resume destination is arbitrary — measured, `pin(2)`/`pin(3)` resumed on hubs 0 and 1.

## Two design points worth review

**The run-queue filter is a first-match walk, not a head-only check.** Head-only is simpler, but it lets an entry pinned to a busy hub block the whole queue: an *unpinned* fiber was held 2.00s behind one pinned to an occupied hub, with three hubs idle. Since a hub only polls this queue when its local queues drain, a target wedged in a blocking C call would strand every woken fiber in the process — the exact failure this queue exists to prevent.

**`mn_fiber(hub=)` can name a reserved offload hub, deliberately.** `RUNLOOM_OFFLOAD_HUBS` reaches its hubs through the same `force_hub` argument to `runloom_mn_fiber_core` that this feature needs, so the two share one door rather than adding a second spawn path (a path bypassing `runloom_greg_link` would reopen the parked-frame GC blind spot). That makes this the one way to put general work on an offload hub, which the offload invariant otherwise forbids — and it is kept on purpose: every *automatic* placement path stays bounded by `runloom_general_hub_count()` and cannot name a reserved hub even by accident, while `offload_fiber()` only round-robins, so without this the four exclusions could only be tested from the outside by inference from timing. The cost is a liveness hazard the caller opts into — pinned to a *busy* offload hub, the fiber strands behind that hub's blocking call. Never a soundness hazard: nothing migrates, and the g sits on that hub's own local FIFO, so it is a hang in a test that asked for one, not corruption. Recorded as the sanctioned exception in `CLAUDE.md`.

## Also in here

- **`G.stack()` reported `'fresh'` for every fiber under migration mode** — it keys off `snap.valid`, which that mode never sets, because the per-g tstate carries the suspended state instead. It now reads the wake state machine there, so waiting for a fiber to park actually terminates.
- `pin_hub1` stores `hub_id + 1` so `0` means unpinned: `slab_alloc`'s memset zeroes everything before `state`, and gs are allocated on paths that never see a pin, so a raw hub id would make every recycled g read as pinned to hub 0.
- Guard rails, because a pin that cannot be honoured is worse than no pin: an out-of-range hub raises `ValueError`, and targeting a hub other than the fiber's own raises `RuntimeError` in the default scheduler, where the pin would be inert rather than wrong.

## Tests

`tests/test_hub_pinning.py` asserts all four destinations on a 4-hub runtime. Unpinned, this workload resumes on hub 0 every time (40/40) — so `pin(1)`/`(2)`/`(3)` each demand an outcome the unpinned scheduler does not produce, and `pin(0)` is the stayed-put control. A pin degraded to a no-op fails three of the four. Needs both CPython migration patches; skips otherwise.

`tests/test_offload_hubs.py` gains two, placed beside the rule they except: a fiber pinned to a reserved hub reports `mn_current_hub() ==` that hub, and an index past the true end of `runloom_hubs[]` still raises `ValueError` (widening the bound must not widen it into placing the fiber elsewhere and making every placement assert vacuous). The first was checked by mutation — narrowing the bound back to the general count makes it fail — so it guards the decision rather than merely passing.

## Verification

Run per `CLAUDE.md` via `tests/run_isolated.py`, on the exact commits here:

- **Patched `3.14.4t` (both migration patches, feature live): 236 passed, 1 skipped, 0 failures.** Feature tests 15/15.
- **Stock `3.14.4t`: 232 passed, 4 not-passed** — `test_cov95_datastack`, `test_monkey_leak`, `test_swarm_coro_stack`, `test_swarm_mn_sched`. All four fail identically on `main` at `8a5f9de8` with the same build; pre-existing, not from this branch.

One note for whoever runs this: `test_monkey_leak.py::test_no_leak_subprocess` is an object-count threshold (`tol 8`) that swings with machine state. It failed 5/5 mid-session on this branch *and* 5/5 on unmodified `main` at the same magnitude (~12–18), then passed again later. Unrelated to this work, but the tolerance looks tight enough to be worth a separate look.

`scripts/check_all_fast.sh` — the local merge gate — has **not** been run; this is the test suite only.

## Draft because

The offload-hub allowance above is a deliberate, documented breach of a stated invariant. It is the one call here that is a judgement rather than a mechanical consequence, and it should get a second opinion before this is a merge candidate. Narrowing it back is a one-line change plus dropping one test.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_016krKvPMyQ2gfWachKszjjy
