### PR TITLE
ci(3.15): add CPython 3.15 (3.15.0rc1) — patches, prerelease support, and the runloom port

### DIFF
--- a/src/patches/cpython315t-tstate-alloc-home.patch
+++ b/src/patches/cpython315t-tstate-alloc-home.patch
@@ -1,0 +1,194 @@
+# CPython 3.15t OPTIONAL feature patch: per-tstate allocation "home"
+#   build flag:  -DPy_TSTATE_ALLOC_HOME      (OFF by default)
+#   pinned to:   Python-3.15.0rc1  (applies at ZERO fuzz: patch -p1 -F0)
+#   series pair: this is the ALLOCATION half for the 3.15 series.  The matching
+#                EXECUTION half is cpython315t-tstate-exec-home.patch; migration
+#                needs BOTH.  Ports of cpython314t-tstate-alloc-home.patch -- NOT
+#                interchangeable (the 3.14 patch rejects on 3.15).
+#
+# Same feature, flag, and accessor API as the 3.13/3.14 patches -- see
+# cpython313t-tstate-alloc-home.patch for the full WHAT/WHY.
+#
+# WHAT CHANGED vs the 3.14 patch (both purely re-anchoring; no semantic change):
+#
+# 1. pycore_tstate.h -- 3.15 inserted `_PyInterpreterFrame base_frame;` right
+#    after `PyThreadState base;`, so the field-insert hunk needed new context.
+#    The `_alloc_home` field still sits immediately after `base` (before
+#    base_frame); the two accessors still follow `} _PyThreadStateImpl;`.
+#
+# 2. obmalloc.c -- 3.15 added two comment lines inside _PyObject_MiRealloc
+#    between the `_PyThreadState_GET()` and the `current_object_heap` read, so
+#    that one redirect hunk needed new context.  The other seven redirects and
+#    the relaxed _PyMem_mi_page_reclaimed assert (added for 3.14, kept by 3.15)
+#    are unchanged.  The debug-only `current_object_heap->debug_offset` read is
+#    deliberately NOT redirected -- it is not an allocation path, matching 3.14.
+#
+# ZERO IMPACT BY DEFAULT / ENABLE / rebuild-everything: identical to the 3.14
+# patch.  With Py_TSTATE_ALLOC_HOME undefined every redirect macro-expands back
+# to tstate->mimalloc and the field + accessors vanish.
+#
+# APPLY:  from the CPython source root:  patch -p1 -F0 < this-file
+# SCOPE:  Include/internal/{pycore_tstate.h,pycore_object_alloc.h}, Objects/obmalloc.c
+#
+--- a/Include/internal/pycore_object_alloc.h
++++ b/Include/internal/pycore_object_alloc.h
+@@ -17,7 +17,7 @@
+ static inline mi_heap_t *
+ _PyObject_GetAllocationHeap(_PyThreadStateImpl *tstate, PyTypeObject *tp)
+ {
+-    struct _mimalloc_thread_state *m = &tstate->mimalloc;
++    struct _mimalloc_thread_state *m = &_PyThreadStateImpl_AllocHome(tstate)->mimalloc;
+     if (_PyType_HasFeature(tp, Py_TPFLAGS_PREHEADER)) {
+         return &m->heaps[_Py_MIMALLOC_HEAP_GC_PRE];
+     }
+@@ -40,7 +40,7 @@
+ {
+ #ifdef Py_GIL_DISABLED
+     _PyThreadStateImpl *tstate = (_PyThreadStateImpl *)_PyThreadState_GET();
+-    struct _mimalloc_thread_state *m = &tstate->mimalloc;
++    struct _mimalloc_thread_state *m = &_PyThreadStateImpl_AllocHome(tstate)->mimalloc;
+     m->current_object_heap = _PyObject_GetAllocationHeap(tstate, tp);
+ #endif
+     void *mem = PyObject_Malloc(size);
+@@ -55,7 +55,7 @@
+ {
+ #ifdef Py_GIL_DISABLED
+     _PyThreadStateImpl *tstate = (_PyThreadStateImpl *)_PyThreadState_GET();
+-    struct _mimalloc_thread_state *m = &tstate->mimalloc;
++    struct _mimalloc_thread_state *m = &_PyThreadStateImpl_AllocHome(tstate)->mimalloc;
+     m->current_object_heap = _PyObject_GetAllocationHeap(tstate, tp);
+ #endif
+     void *mem = PyObject_Realloc(ptr, size);
+--- a/Include/internal/pycore_tstate.h
++++ b/Include/internal/pycore_tstate.h
+@@ -31,6 +31,23 @@
+     // semi-public fields are in PyThreadState.
+     PyThreadState base;
+ 
++#if defined(Py_GIL_DISABLED) && defined(Py_TSTATE_ALLOC_HOME)
++    /* The tstate whose per-thread ALLOCATOR (mimalloc heap + qsbr/page-reclaim)
++       the running OS thread borrows.  NULL (the common case) == "this tstate".
++
++       A migratable coroutine/fiber carries an execution-only tstate (portable
++       frames/exc/recursion) and, on every resume, points its alloc-home at the
++       OS-thread tstate now running it.  Its objects are then allocated on -- and
++       reclaimed by -- the running thread's own heap, decoupling portable
++       EXECUTION from thread-affine ALLOCATION.  Such a tstate carries no heap of
++       its own (no per-fiber heap pages; nothing extra for the GC to walk) and
++       can resume on any OS thread with no cross-thread heap hazard.
++
++       Opt-in: with Py_TSTATE_ALLOC_HOME undefined the field and every redirect
++       vanish and the build is byte-for-byte stock CPython. */
++    struct _PyThreadStateImpl *_alloc_home;
++#endif
++
+     // Embedded base frame - sentinel at the bottom of the frame stack.
+     // Used by profiling/sampling to detect incomplete stack traces.
+     _PyInterpreterFrame base_frame;
+@@ -110,6 +127,26 @@
+ #endif
+ } _PyThreadStateImpl;
+ 
++#if defined(Py_GIL_DISABLED) && defined(Py_TSTATE_ALLOC_HOME)
++/* The tstate whose allocator the running thread should use (see _alloc_home). */
++static inline _PyThreadStateImpl *
++_PyThreadStateImpl_AllocHome(_PyThreadStateImpl *tstate)
++{
++    _PyThreadStateImpl *home = tstate->_alloc_home;
++    return home != NULL ? home : tstate;
++}
++/* Borrow `home`'s allocator for `tstate` (home == tstate resets to self). */
++static inline void
++_PyThreadState_SetAllocHome(PyThreadState *tstate, PyThreadState *home)
++{
++    ((_PyThreadStateImpl *)tstate)->_alloc_home =
++        (home != tstate) ? (_PyThreadStateImpl *)home : NULL;
++}
++#else
++#  define _PyThreadStateImpl_AllocHome(tstate) (tstate)
++#endif
++
++
+ #ifdef __cplusplus
+ }
+ #endif
+--- a/Objects/obmalloc.c
++++ b/Objects/obmalloc.c
+@@ -212,7 +212,13 @@
+         if (mi_page_all_free(page)) {
+             assert(page->qsbr_node.next == NULL);
+             _PyThreadStateImpl *tstate = tstate_from_heap(mi_page_heap(page));
+-            assert(tstate == (_PyThreadStateImpl *)_PyThreadState_GET());
++            /* With Py_TSTATE_ALLOC_HOME the running tstate may be an
++               execution-only fiber tstate that BORROWS this heap, so the page's
++               owner is the running tstate's alloc home rather than the running
++               tstate itself.  Expands to the original assert when the feature is
++               off. */
++            assert(tstate == _PyThreadStateImpl_AllocHome(
++                                 (_PyThreadStateImpl *)_PyThreadState_GET()));
+             page->retire_expire = 0;
+             llist_insert_tail(&tstate->mimalloc.page_list, &page->qsbr_node);
+         }
+@@ -232,7 +238,7 @@
+     }
+ 
+     _PyThreadStateImpl *tstate = (_PyThreadStateImpl *)_PyThreadState_GET();
+-    struct llist_node *head = &tstate->mimalloc.page_list;
++    struct llist_node *head = &_PyThreadStateImpl_AllocHome(tstate)->mimalloc.page_list;
+     if (llist_empty(head)) {
+         return;
+     }
+@@ -261,7 +267,7 @@
+ {
+ #ifdef Py_GIL_DISABLED
+     _PyThreadStateImpl *tstate = (_PyThreadStateImpl *)_PyThreadState_GET();
+-    mi_heap_t *heap = &tstate->mimalloc.heaps[_Py_MIMALLOC_HEAP_MEM];
++    mi_heap_t *heap = &_PyThreadStateImpl_AllocHome(tstate)->mimalloc.heaps[_Py_MIMALLOC_HEAP_MEM];
+     return mi_heap_malloc(heap, size);
+ #else
+     return mi_malloc(size);
+@@ -273,7 +279,7 @@
+ {
+ #ifdef Py_GIL_DISABLED
+     _PyThreadStateImpl *tstate = (_PyThreadStateImpl *)_PyThreadState_GET();
+-    mi_heap_t *heap = &tstate->mimalloc.heaps[_Py_MIMALLOC_HEAP_MEM];
++    mi_heap_t *heap = &_PyThreadStateImpl_AllocHome(tstate)->mimalloc.heaps[_Py_MIMALLOC_HEAP_MEM];
+     return mi_heap_calloc(heap, nelem, elsize);
+ #else
+     return mi_calloc(nelem, elsize);
+@@ -285,7 +291,7 @@
+ {
+ #ifdef Py_GIL_DISABLED
+     _PyThreadStateImpl *tstate = (_PyThreadStateImpl *)_PyThreadState_GET();
+-    mi_heap_t *heap = &tstate->mimalloc.heaps[_Py_MIMALLOC_HEAP_MEM];
++    mi_heap_t *heap = &_PyThreadStateImpl_AllocHome(tstate)->mimalloc.heaps[_Py_MIMALLOC_HEAP_MEM];
+     return mi_heap_realloc(heap, ptr, size);
+ #else
+     return mi_realloc(ptr, size);
+@@ -303,7 +309,7 @@
+ {
+ #ifdef Py_GIL_DISABLED
+     _PyThreadStateImpl *tstate = (_PyThreadStateImpl *)_PyThreadState_GET();
+-    mi_heap_t *heap = tstate->mimalloc.current_object_heap;
++    mi_heap_t *heap = _PyThreadStateImpl_AllocHome(tstate)->mimalloc.current_object_heap;
+     return mi_heap_malloc(heap, nbytes);
+ #else
+     return mi_malloc(nbytes);
+@@ -315,7 +321,7 @@
+ {
+ #ifdef Py_GIL_DISABLED
+     _PyThreadStateImpl *tstate = (_PyThreadStateImpl *)_PyThreadState_GET();
+-    mi_heap_t *heap = tstate->mimalloc.current_object_heap;
++    mi_heap_t *heap = _PyThreadStateImpl_AllocHome(tstate)->mimalloc.current_object_heap;
+     return mi_heap_calloc(heap, nelem, elsize);
+ #else
+     return mi_calloc(nelem, elsize);
+@@ -335,7 +341,7 @@
+         return ptr;
+     }
+ 
+-    mi_heap_t *heap = tstate->mimalloc.current_object_heap;
++    mi_heap_t *heap = _PyThreadStateImpl_AllocHome(tstate)->mimalloc.current_object_heap;
+     void* newp = mi_heap_malloc(heap, nbytes);
+     if (newp == NULL) {
+         return NULL;

--- a/src/patches/cpython315t-tstate-exec-home.patch
+++ b/src/patches/cpython315t-tstate-exec-home.patch
@@ -1,0 +1,161 @@
+# CPython 3.15t OPTIONAL feature patch: thread-state EXECUTION home
+#   build flag:  -DPy_TSTATE_EXEC_HOME      (OFF by default)
+#   pinned to:   Python-3.15.0rc1  (applies at ZERO fuzz: patch -p1 -F0)
+#   series pair: this is the EXECUTION half for the 3.15 series.  The matching
+#                ALLOCATION half is cpython315t-tstate-alloc-home.patch; migration
+#                needs BOTH.  Port of cpython314t-tstate-exec-home.patch -- NOT
+#                interchangeable (the 3.14 patch rejects on 3.15).
+#
+# Same feature, flag, and _Py_TID_ASM witness as the 3.13/3.14 patches -- see
+# cpython314t-tstate-exec-home.patch for the full WHAT/WHY, codegen evidence,
+# measured cost, and caveats (no LTO; do not annotate _PyThreadState_GetCurrent()
+# pure/const; MSVC intrinsics not covered).  All of it applies here unchanged.
+#
+# WHAT CHANGED vs the 3.14 patch -- purely structural, no semantic change:
+#
+# 1. _Py_ThreadId() MOVED.  3.15 relocated it (and _Py_GetThreadLocal_Addr) from
+#    Include/object.h to Include/cpython/object.h, and dropped the
+#    `&& !defined(Py_LIMITED_API)` from its `#if defined(Py_GIL_DISABLED)` guard.
+#    So this patch targets Include/cpython/object.h.  The asm templates are
+#    byte-identical to 3.14, so the transformation is the same: define _Py_TID_ASM
+#    (volatile iff Py_TSTATE_EXEC_HOME) and route every thread-pointer READ through
+#    it.  The `register uintptr_t tp __asm__ ("r13")` / `("r2")` constraints are
+#    left alone -- bindings, not reads.
+#
+# 2. _PyThreadState_GET() guard simplified.  3.15's guard is
+#    `#if !defined(Py_BUILD_CORE_MODULE)` (3.14 also required HAVE_THREAD_LOCAL),
+#    so the added `&& !defined(Py_TSTATE_EXEC_HOME)` clause attaches to the new
+#    form.  Semantics identical: under exec-home the read goes out-of-line.
+#
+# 3. Python/pystate.c -- the Py_NO_INLINE + comment on _PyThreadState_GetCurrent()
+#    is unchanged from the 3.14 patch and applies to 3.15 as-is.
+#
+# ZERO IMPACT BY DEFAULT: with the flag undefined _Py_TID_ASM expands to plain
+# __asm__ and _PyThreadState_GET() keeps its inline thread-local read.  No ABI
+# change.  APPLY BOTH FILES' HUNKS -- the flag is armed in pyconfig.h regardless,
+# so a partial build advertises the feature while lacking it; check with
+# `grep _Py_TID_ASM Include/cpython/object.h`.
+#
+# APPLY:  from the CPython source root:  patch -p1 -F0 < this-file
+# SCOPE:  Include/cpython/object.h, Include/internal/pycore_pystate.h, Python/pystate.c
+#
+--- a/Include/cpython/object.h
++++ b/Include/cpython/object.h
+@@ -506,6 +506,21 @@
+ #if defined(Py_GIL_DISABLED)
+ PyAPI_FUNC(uintptr_t) _Py_GetThreadLocal_Addr(void);
+ 
++/* Py_TSTATE_EXEC_HOME: volatile, so the thread-pointer read below cannot be
++   hoisted, CSE'd or deleted.  A stackful fiber (greenlet/runloom-style) can park
++   on one OS thread and resume on another carrying its C frames, so a cached tid
++   names the ORIGIN thread.  _Py_ThreadId() gates _Py_IsOwnedByCurrentThread(),
++   so a stale tid routes a refcount update down the non-atomic ob_ref_local path
++   from a thread that does not own the object -- losing updates when the true
++   owner does the same concurrently.  (Mechanism read off refcount.h; no failure
++   has been pinned on it.  Kept because it measures free and a lost refcount
++   update is silent.)  MSVC's intrinsic reads are not covered. */
++#ifdef Py_TSTATE_EXEC_HOME
++#  define _Py_TID_ASM __asm__ __volatile__
++#else
++#  define _Py_TID_ASM __asm__
++#endif
++
+ static inline uintptr_t
+ _Py_ThreadId(void)
+ {
+@@ -523,24 +538,24 @@
+ #elif defined(__MINGW32__) && defined(_M_ARM64)
+     tid = __getReg(18);
+ #elif defined(__i386__)
+-    __asm__("{movl %%gs:0, %0|mov %0, dword ptr gs:[0]}" : "=r" (tid));  // 32-bit always uses GS
++    _Py_TID_ASM("{movl %%gs:0, %0|mov %0, dword ptr gs:[0]}" : "=r" (tid));  // 32-bit always uses GS
+ #elif defined(__MACH__) && defined(__x86_64__)
+-    __asm__("{movq %%gs:0, %0|mov %0, qword ptr gs:[0]}" : "=r" (tid));  // x86_64 macOSX uses GS
+-#elif defined(__x86_64__)
+-    __asm__("{movq %%fs:0, %0|mov %0, qword ptr fs:[0]}" : "=r" (tid));  // x86_64 Linux, BSD uses FS
++    _Py_TID_ASM("{movq %%gs:0, %0|mov %0, qword ptr gs:[0]}" : "=r" (tid));  // x86_64 macOSX uses GS
++#elif defined(__x86_64__)
++    _Py_TID_ASM("{movq %%fs:0, %0|mov %0, qword ptr fs:[0]}" : "=r" (tid));  // x86_64 Linux, BSD uses FS
+ #elif defined(__arm__) && __ARM_ARCH >= 7
+-    __asm__ ("mrc p15, 0, %0, c13, c0, 3\nbic %0, %0, #3" : "=r" (tid));
++    _Py_TID_ASM ("mrc p15, 0, %0, c13, c0, 3\nbic %0, %0, #3" : "=r" (tid));
+ #elif defined(__aarch64__) && defined(__APPLE__)
+-    __asm__ ("mrs %0, tpidrro_el0" : "=r" (tid));
++    _Py_TID_ASM ("mrs %0, tpidrro_el0" : "=r" (tid));
+ #elif defined(__aarch64__)
+-    __asm__ ("mrs %0, tpidr_el0" : "=r" (tid));
++    _Py_TID_ASM ("mrs %0, tpidr_el0" : "=r" (tid));
+ #elif defined(__powerpc64__)
+     #if defined(__clang__) && _Py__has_builtin(__builtin_thread_pointer)
+     tid = (uintptr_t)__builtin_thread_pointer();
+     #else
+     // r13 is reserved for use as system thread ID by the Power 64-bit ABI.
+     register uintptr_t tp __asm__ ("r13");
+-    __asm__("" : "=r" (tp));
++    _Py_TID_ASM("" : "=r" (tp));
+     tid = tp;
+     #endif
+ #elif defined(__powerpc__)
+@@ -549,7 +564,7 @@
+     #else
+     // r2 is reserved for use as system thread ID by the Power 32-bit ABI.
+     register uintptr_t tp __asm__ ("r2");
+-    __asm__ ("" : "=r" (tp));
++    _Py_TID_ASM ("" : "=r" (tp));
+     tid = tp;
+     #endif
+ #elif defined(__s390__) && defined(__GNUC__)
+@@ -561,7 +576,7 @@
+     tid = (uintptr_t)__builtin_thread_pointer();
+     #else
+     // tp is Thread Pointer provided by the RISC-V ABI.
+-    __asm__ ("mv %0, tp" : "=r" (tid));
++    _Py_TID_ASM ("mv %0, tp" : "=r" (tid));
+     #endif
+ #else
+     // Fallback to a portable implementation if we do not have a faster
+--- a/Include/internal/pycore_pystate.h
++++ b/Include/internal/pycore_pystate.h
+@@ -115,9 +115,13 @@
+ static inline PyThreadState*
+ _PyThreadState_GET(void)
+ {
+-#if !defined(Py_BUILD_CORE_MODULE)
++#if !defined(Py_BUILD_CORE_MODULE) && !defined(Py_TSTATE_EXEC_HOME)
+     return _Py_tss_tstate;
+ #else
++    /* With Py_TSTATE_EXEC_HOME this is deliberately an out-of-line call:
++       the ADDRESS of the _Py_tss_tstate thread-local must be recomputed on the
++       OS thread that is running RIGHT NOW.  See the comment on
++       _PyThreadState_GetCurrent() in Python/pystate.c. */
+     return _PyThreadState_GetCurrent();
+ #endif
+ }
+--- a/Python/pystate.c
++++ b/Python/pystate.c
+@@ -106,7 +106,25 @@
+     if (tstate == current_fast_get()) { \
+         _Py_FatalErrorFormat(__func__, "tstate %p is still current", tstate); \
+     }
++
++/* Py_TSTATE_EXEC_HOME: out of line, and it must stay un-foldable.
++
++   Compilers treat "which thread am I" as loop-invariant and cache it across
++   calls -- clang -O2 caches the slot ADDRESS on Darwin/AArch64 and the loaded
++   VALUE on Linux x86-64/AArch64.  Sound for OS threads, whose stacks never move;
++   wrong for a stackful fiber that parks on one thread and resumes on another,
++   whose C frames travel with it.  Every inlined _PyThreadState_GET() in those
++   frames then resolves against the ORIGIN thread: NULL if it has since detached
++   (SIGSEGV in e.g. _Py_Dealloc -> _Py_RecursionLimit_GetMargin), or a
++   valid-but-WRONG tstate if it is running something else (silent corruption).
+ 
++   Three things keep this un-foldable and all are load-bearing: it is a real
++   cross-TU call, so do NOT build with LTO; it must NOT be annotated pure/const
++   (it looks eligible, and that would re-license exactly this folding);
++   Py_NO_INLINE covers callers inside this TU. */
++#ifdef Py_TSTATE_EXEC_HOME
++Py_NO_INLINE
++#endif
+ PyThreadState *
+ _PyThreadState_GetCurrent(void)
+ {

--- a/src/runloom/aio/loop_subprocess.py
+++ b/src/runloom/aio/loop_subprocess.py
@@ -75,12 +75,19 @@ class _LoopSubprocessMixin(object):
         """Run func(*args) on a thread pool.  Returns a RunloomFuture
         that resolves when the thread completes.  We hand out a real
         threadpool via concurrent.futures."""
-        import concurrent.futures as _cf
+        # Import ThreadPoolExecutor from its submodule, NOT as
+        # `concurrent.futures.ThreadPoolExecutor`.  On 3.15 that name is a PEP 810
+        # `lazy from .thread import ThreadPoolExecutor` binding, and lazy-import
+        # resolution does not fire inside a runloom fiber -- it resolves on the main
+        # thread and on plain OS threads, but a fiber access returns the unresolved
+        # proxy ("'lazy_import' object is not callable").  A direct submodule import
+        # is a normal import that works in a fiber; equivalent on 3.13/3.14.
+        from concurrent.futures.thread import ThreadPoolExecutor
         self._check_closed()
         if executor is None:
             # Lazy-init default pool.
             if self._default_executor is None:
-                self._default_executor = _cf.ThreadPoolExecutor(max_workers=8)
+                self._default_executor = ThreadPoolExecutor(max_workers=8)
             executor = self._default_executor
         fut = RunloomFuture(loop=self)
         cf_fut = executor.submit(func, *args)

--- a/src/runloom_c/runloom_iframe.c
+++ b/src/runloom_c/runloom_iframe.c
@@ -154,11 +154,20 @@ int runloom_iframe_walk(void *top, int max, runloom_iframe_cb cb, void *ctx)
     _PyInterpreterFrame *f = (_PyInterpreterFrame *)top;
     int n = 0;
     while (f != NULL && n < max) {
-        /* Skip the C-stack trampoline shim frames that bracket a real
-         * call; they carry no user code. */
+        /* Skip the trampoline/shim frames that bracket a real call; they carry
+         * no user code. */
+#if PY_VERSION_HEX >= 0x030F0000
+        /* 3.15 removed FRAME_OWNED_BY_CSTACK.  _PyFrame_IsIncomplete is CPython's
+         * own "not a complete user frame" predicate (interpreter-entry sentinel +
+         * not-yet-traceable shims) -- exactly what a traceback skips.  It tests
+         * owner >= FRAME_OWNED_BY_INTERPRETER first, so _PyFrame_GetCode inside it
+         * is only reached for real code-bearing frames. */
+        if (!_PyFrame_IsIncomplete(f)) {
+#else
         if (f->owner != FRAME_OWNED_BY_CSTACK) {
+#endif
 #if PY_VERSION_HEX >= 0x030E0000
-            /* 3.14: f_executable is a tagged _PyStackRef, not a PyObject*. */
+            /* 3.14+: f_executable is a tagged _PyStackRef, not a PyObject*. */
             PyObject *exec = PyStackRef_AsPyObjectBorrow(f->f_executable);
 #else
             PyObject *exec = f->f_executable;
@@ -368,22 +377,35 @@ int runloom_gc_in_subtract_pass(PyObject *self)
  * reference is NOT part of the refcount (update_refs already stripped the
  * deferred bias), so the SUBTRACT pass must skip it -- visiting would
  * double-subtract and free a LIVE object -- while every other pass treats it as a
- * regular reference so propagation from the anchor keeps its referent alive. */
+ * regular reference so propagation from the anchor keeps its referent alive.
+ *
+ * 3.15 exports _PyGC_VisitStackRef, which performs exactly this discrimination
+ * itself -- keyed on the visitproc identity (visit_decref / visit_decref_unreachable
+ * ARE the subtract pass) rather than a caller-supplied flag.  So on 3.15+ we defer
+ * to it: the `subtract` argument is unused, and PyStackRef_IsDeferred (used by the
+ * 3.14 branch) was removed in favour of that self-discrimination.  We still guard
+ * NullOrInt here, exactly as the _Py_VISIT_STACKREF macro does before calling. */
 static int runloom_visit_stackref(_PyStackRef *ref, visitproc visit, void *arg,
                                   int subtract)
 {
-    PyObject *op;
     if (PyStackRef_IsNullOrInt(*ref)) {
         return 0;
     }
+#if PY_VERSION_HEX >= 0x030F0000
+    (void)subtract;
+    return _PyGC_VisitStackRef(ref, visit, arg);
+#else
     if (subtract && PyStackRef_IsDeferred(*ref)) {
         return 0;
     }
-    op = PyStackRef_AsPyObjectBorrow(*ref);
-    if (op != NULL) {
-        return visit(op, arg);
+    {
+        PyObject *op = PyStackRef_AsPyObjectBorrow(*ref);
+        if (op != NULL) {
+            return visit(op, arg);
+        }
     }
     return 0;
+#endif
 }
 
 int runloom_gcvisit_frame_chain(void *top, visitproc visit, void *arg, int subtract)

--- a/tests/test_asyncio_conformance.py
+++ b/tests/test_asyncio_conformance.py
@@ -65,8 +65,24 @@ if not _HAVE_CPYTHON_TESTS:
 # (Previously this listed test_sock_client_ops, test_unix_sock_client_ops and
 # test_sock_accept; all three were FIXED -- sock_* now enforce asyncio's
 # non-blocking precondition in debug mode and sock_accept returns a non-blocking
-# socket -- so BaseSockTestsMixin is now 13/13.)
-_KNOWN_GAPS = {}
+# socket -- so BaseSockTestsMixin was 13/13 through 3.14.)
+#
+# 3.15 added a 14th test (below); it is the one remaining characterised gap.
+_KNOWN_GAPS = {
+    "test_sock_accept_racing":
+        "gh-153761 (new in 3.15): if a sock_accept() is cancelled in the same "
+        "loop turn its listener becomes readable, asyncio requires the cancel to "
+        "win -- the future is cancelled and the pending connection survives. "
+        "Stock asyncio gets this for free because the fd-ready callback and the "
+        "earlier-queued call_soon(task.cancel) run FIFO in one ready queue (and "
+        "gh-153761 made the fd-ready callback re-check fut.cancelled()).  runloom "
+        "parks sock_accept in the C netpoll (runloom_c.wait_fd), so the fd-ready "
+        "wake is delivered straight to the fiber rather than through the loop's "
+        "ready queue -- it can resume the fiber and complete accept() before the "
+        "one-shot cancel is delivered, so CancelledError is not raised.  A real "
+        "cancellation-ordering gap in the wait_fd/cancel interaction; skipped "
+        "(documented, not silenced) as a TODO, not fixed here.",
+}
 
 
 class RunloomSockLowlevelConformance(_tsl.BaseSockTestsMixin, _test_utils.TestCase):
@@ -89,7 +105,11 @@ def _make_skip(reason):
 
 
 for _name, _reason in _KNOWN_GAPS.items():
-    setattr(RunloomSockLowlevelConformance, _name, _make_skip(_reason))
+    # Only shadow a method the upstream mixin actually defines on THIS interpreter
+    # (test_sock_accept_racing is 3.15+), so older versions don't grow a spurious
+    # skipped test that upstream never had.
+    if hasattr(_tsl.BaseSockTestsMixin, _name):
+        setattr(RunloomSockLowlevelConformance, _name, _make_skip(_reason))
 
 
 if __name__ == "__main__":

--- a/tools/ci/lib.sh
+++ b/tools/ci/lib.sh
@@ -58,12 +58,16 @@ rl_ci_summary() {
 # the series, the patch pair, the sha256, the interpreter basename, the test
 # exclusions -- is DERIVED from it here, so callers only ever pass a version.
 
-# rl_validate_version 3.14.4 -> ok, else die.  Guards every downstream eval/awk.
+# rl_validate_version 3.14.4 / 3.15.0rc1 -> ok, else die.  Guards downstream awk.
+# Accepts major.minor.patch, optionally followed by a prerelease tag (a1/b2/rc1);
+# the tag is fine because series/majmin are derived from $1 and $2 only, and the
+# sha/patch lookup keys on the exact version string.
 rl_validate_version() {
-    case "$1" in
-        [0-9]*.[0-9]*.[0-9]*)
-            case "$1" in *[!0-9.]*) rl_die "bad version '$1' (non-numeric)";; esac ;;
-        *) rl_die "bad version '$1' -- expected major.minor.patch, e.g. 3.14.4" ;;
+    # Strip a trailing prerelease tag: longest run from the first non-[0-9.] char.
+    _core="${1%%[!0-9.]*}"
+    case "$_core" in
+        [0-9]*.[0-9]*.[0-9]*) : ;;
+        *) rl_die "bad version '$1' -- expected major.minor.patch[tag], e.g. 3.14.4 or 3.15.0rc1" ;;
     esac
 }
 
@@ -148,11 +152,16 @@ rl_fetch_cpython() {
         return 0
     fi
     rl_rm -f "$_tar"
+    # python.org keeps PRERELEASE tarballs under the FINAL version's directory:
+    #   .../3.15.0/Python-3.15.0rc1.tgz   (dir 3.15.0, file Python-3.15.0rc1.tgz)
+    # so the directory is the version with any prerelease tag stripped, while the
+    # filename keeps the full version.
+    _dir="${_ver%%[!0-9.]*}"
     # The bytes ARE pinned: the sha256 from versions.env is checked immediately
     # below and a mismatch is fatal (the cache-hit path above re-checks too).
     # Not routed through rl_fetch_pinned only because this predates it.
-    _url="${RL_CI_PY_MIRROR}/${_ver}/Python-${_ver}.tgz"
-    curl -fsSL "$_url" -o "$_tar" || rl_die "download failed: Python-${_ver}.tgz"  # download-pin-lint: allow -- sha256 from versions.env verified below; mismatch is fatal
+    _url="${RL_CI_PY_MIRROR}/${_dir}/Python-${_ver}.tgz"
+    curl -fsSL "$_url" -o "$_tar" || rl_die "download failed: $_url"  # download-pin-lint: allow -- sha256 from versions.env verified below; mismatch is fatal
     _got="$(rl_sha256 "$_tar")"
     [ "$_got" = "$_sha" ] || rl_die "sha256 MISMATCH for Python-${_ver}.tgz
   pinned: $_sha
@@ -195,8 +204,10 @@ $_rej"
 # thing standing between that and a released interpreter.
 rl_verify_witnesses() {
     _src="$1"
-    grep -q '_Py_TID_ASM' "$_src/Include/object.h" \
-        || rl_die "exec-home witness missing: _Py_TID_ASM not in Include/object.h"
+    # _Py_ThreadId lives in Include/object.h on 3.13/3.14 but moved to
+    # Include/cpython/object.h in 3.15, so accept the macro in either.
+    grep -qs '_Py_TID_ASM' "$_src/Include/object.h" "$_src/Include/cpython/object.h" \
+        || rl_die "exec-home witness missing: _Py_TID_ASM not in Include/object.h or Include/cpython/object.h"
     grep -q '_PyThreadStateImpl_AllocHome' "$_src/Include/internal/pycore_tstate.h" \
         || rl_die "alloc-home witness missing: _PyThreadStateImpl_AllocHome not in pycore_tstate.h"
     grep -q 'Py_NO_INLINE' "$_src/Python/pystate.c" \

--- a/tools/ci/versions.env
+++ b/tools/ci/versions.env
@@ -19,6 +19,7 @@
 RL_CI_PINS="
 3.14.4     b4c059d5895f030e7df9663894ce3732bfa1b32cd3ab2883980266a45ce3cb3b
 3.13.13    f9cde7b0e2ec8165d7326e2a0f59ea2686ce9d0c617dbbb3d66a7e54d31b74b9
+3.15.0rc1  32c2b9878bbd6ac3ceb138c5b6c880345ce9d33388b399378c0da6fc7cb3bfbc
 "
 
 # ---- default version set ----------------------------------------------------
@@ -54,6 +55,25 @@ RL_CI_PINS="
 #      resolves it.)
 PY314_TEST_EXCLUDE="test_build_details test_warnings"
 PY313_TEST_EXCLUDE=""
+# 315 (3.15.0rc1): the migration patches apply at zero fuzz, build a working
+# free-threaded interpreter, and cause ZERO stdlib regression -- verified by A/B
+# against an unpatched 3.15.0rc1t build.  3.15 also FIXED the build_details bug
+# 3.14 needs excluded (base_interpreter now uses LDVERSION = "python3.15t").
+# No exclusions are set: the only stdlib non-passes are PRE-EXISTING UPSTREAM
+# free-threaded rc issues (identical patched vs unpatched), so they belong to
+# CPython, not this pin, and may well be fixed by 3.15.0 final:
+#   test_import: ModexportTests.test_from_modexport{,_create_nonmodule}_gil_used
+#                -- assert the GIL re-enables when a Py_MOD_GIL_USED extension is
+#                   imported in a subinterpreter; fails on the FT build itself.
+#   test_warnings: "env changed" -- the test leaks warnings.filters / asyncio
+#                   policy (harness hygiene).
+# They are left visible (not excluded) because 3.15 is a PRERELEASE and is NOT
+# in the default RL_CI_VERSIONS; excluding rc-stage upstream bugs prematurely
+# would hide them.  NOTE also: runloom's OWN C extension does not yet build
+# against 3.15 (runloom_iframe.c uses FRAME_OWNED_BY_CSTACK / PyStackRef_IsDeferred,
+# both reworked in 3.15) -- a separate, memory-safety-sensitive runloom port, not
+# a patch issue.  So 3.15 is "patches verified" but not yet release-track.
+PY315_TEST_EXCLUDE=""
 
 # ---- feature flags ----------------------------------------------------------
 # What the whole exercise is for; a build without them is stock CPython.

--- a/tools/ci/versions.env
+++ b/tools/ci/versions.env
@@ -25,7 +25,7 @@ RL_CI_PINS="
 # ---- default version set ----------------------------------------------------
 # Used by a no-argument run and by the push-to-main release job.  Override with
 # RL_CI_VERSIONS="3.14.4 ..." or the workflow's `versions` input.
-: "${RL_CI_VERSIONS:=3.14.4 3.13.13}"
+: "${RL_CI_VERSIONS:=3.14.4 3.13.13 3.15.0rc1}"
 
 # ---- patch selection --------------------------------------------------------
 # Patches are selected by MAJOR.MINOR (the "series", e.g. 3.14.* -> 314).  Both
@@ -59,21 +59,24 @@ PY313_TEST_EXCLUDE=""
 # free-threaded interpreter, and cause ZERO stdlib regression -- verified by A/B
 # against an unpatched 3.15.0rc1t build.  3.15 also FIXED the build_details bug
 # 3.14 needs excluded (base_interpreter now uses LDVERSION = "python3.15t").
-# No exclusions are set: the only stdlib non-passes are PRE-EXISTING UPSTREAM
-# free-threaded rc issues (identical patched vs unpatched), so they belong to
-# CPython, not this pin, and may well be fixed by 3.15.0 final:
+# runloom's own C extension now builds on 3.15 (the runloom_iframe.c port to
+# 3.15's frame/stackref rework: FRAME_OWNED_BY_CSTACK removed -> _PyFrame_IsIncomplete;
+# PyStackRef_IsDeferred removed -> the exported, self-discriminating
+# _PyGC_VisitStackRef), so 3.15 is now in the default matrix.
+#
+# Two stdlib non-passes remain -- excluded below (like 314's) so a default-matrix
+# build stays green.  Both are PRE-EXISTING UPSTREAM free-threaded rc issues,
+# PROVEN so by an A/B run: the SAME subtests fail on a stock, unpatched
+# `./configure --disable-gil` 3.15.0rc1t (patched == stock, identical subtests).
+# So they belong to CPython, not this pin (and may be fixed by 3.15.0 final) --
+# the exclusion is NEVER hiding a runloom-caused failure, which is exactly what
+# the A/B rules out:
 #   test_import: ModexportTests.test_from_modexport{,_create_nonmodule}_gil_used
 #                -- assert the GIL re-enables when a Py_MOD_GIL_USED extension is
 #                   imported in a subinterpreter; fails on the FT build itself.
 #   test_warnings: "env changed" -- the test leaks warnings.filters / asyncio
-#                   policy (harness hygiene).
-# They are left visible (not excluded) because 3.15 is a PRERELEASE and is NOT
-# in the default RL_CI_VERSIONS; excluding rc-stage upstream bugs prematurely
-# would hide them.  NOTE also: runloom's OWN C extension does not yet build
-# against 3.15 (runloom_iframe.c uses FRAME_OWNED_BY_CSTACK / PyStackRef_IsDeferred,
-# both reworked in 3.15) -- a separate, memory-safety-sensitive runloom port, not
-# a patch issue.  So 3.15 is "patches verified" but not yet release-track.
-PY315_TEST_EXCLUDE=""
+#                   policy (harness hygiene); same signature verified stock on 314.
+PY315_TEST_EXCLUDE="test_import test_warnings"
 
 # ---- feature flags ----------------------------------------------------------
 # What the whole exercise is for; a build without them is stock CPython.


### PR DESCRIPTION
Adds **CPython 3.15 (3.15.0rc1)** as a third series to the patched-CPython CI, and ports runloom's C extension to 3.15's frame/stackref rework so the patched 3.15 build is release-track rather than interpreter-only.

Rebased onto current `main` (`8a5f9de8`) — two commits, no merge commits. The earlier 3.13/3.14 CI work this was originally stacked on is already in `main` (you merged it after #3), so only the 3.15 delta remains.

### What's here

**1. `ci(3.15)`: the series + prerelease support** — 395 lines, patches and CI only.

All four existing patches reject on 3.15.0rc1 (genuinely new series), so both halves are ported to `cpython315t-*.patch`, each applying at **zero fuzz**:
- *alloc-home*: re-anchoring only — 3.15 inserted `_PyInterpreterFrame base_frame` after `PyThreadState base`, and added two comment lines inside `_PyObject_MiRealloc`.
- *exec-home*: structural — 3.15 **moved** `_Py_ThreadId` from `Include/object.h` to `Include/cpython/object.h`. The asm templates are byte-identical, so the `_Py_TID_ASM` transform is the same, just retargeted. `pystate.c` unchanged.

Plus the CI plumbing a new series and a prerelease need: `rl_validate_version` accepts an optional `rc1`/`a1`/`b2` tag; `rl_fetch_cpython` strips that tag for the *directory* only (python.org keeps prerelease tarballs under the final version's dir — `.../3.15.0/Python-3.15.0rc1.tgz`); `rl_verify_witnesses` accepts `_Py_TID_ASM` in either header.

**2. `ci(3.15)`: make runloom itself build + pass** — 77 lines.
- `runloom_iframe.c`: 3.15 removed `FRAME_OWNED_BY_CSTACK` (→ CPython's own `_PyFrame_IsIncomplete`) and `PyStackRef_IsDeferred` (→ the exported, self-discriminating `_PyGC_VisitStackRef` — exactly what the existing code comments anticipated for 3.15+). Guarded `PY_VERSION_HEX >= 0x030F0000`; **3.13/3.14 take the original path unchanged.**
- `aio/loop_subprocess.py`: 3.15's PEP 810 `lazy from .thread import ThreadPoolExecutor` binding doesn't resolve inside a runloom fiber (it resolves on the main thread and on plain OS threads, but a fiber access returns the unresolved proxy). Importing the class from its submodule is a normal import that works in a fiber, and is equivalent on 3.13/3.14.

### On skipped tests

Given your note on #3, this deliberately keeps skips to a minimum and scopes each one:

- **One runloom test**, `test_sock_accept_racing` — new in 3.15 (gh-153761) and **version-gated**: the skip is only installed `if hasattr(_tsl.BaseSockTestsMixin, _name)`, so 3.13/3.14 don't grow a skip that upstream never had, and `check_all_fast` on the existing series is untouched. It's a real, characterised gap (runloom parks `sock_accept` in the C netpoll, so the fd-ready wake reaches the fiber directly instead of through the loop's ready queue, and can beat the one-shot cancel) — recorded with that reasoning as a TODO, not silenced.
- **Two stdlib exclusions** (`test_import`, `test_warnings`), each **A/B-proven upstream**: the identical subtests fail on a stock, unpatched `./configure --disable-gil` 3.15.0rc1t. Not hiding a runloom- or patch-caused failure. 3.15 also *fixed* the `test_build_details` bug 3.14 needs excluded.

### Verification (darwin-arm64, re-run after the rebase)

- Zero-fuzz patch gate re-run on **all three** series (3.13.13 / 3.14.4 / 3.15.0rc1) — clean, witnesses present.
- Prerelease fetch exercised end-to-end from a cold cache: correct URL, sha256 matches the pin.
- **3.14t regression check — identical to `main`.** Full suite on the rebased branch and on unmodified `main`, same box, same interpreter: *231 passed, 1 skipped, same 4 files not passing* on both. This change is a no-op for the existing series.
- **Patched 3.15.0rc1t**: `build_ext` clean (so `main`'s newer C code also compiles against 3.15), runloom suite **234 passed, 1 documented skip, 1 failure**. That failure is `test_monkey_leak.py::test_no_leak_subprocess`, which fails identically on unmodified `main` under a stock 3.14t (`leaked ~16 objects over 25 iters, tol 8`) — pre-existing, not from this PR.
- CPython stdlib suite: green with the two exclusions above. Not re-run post-rebase, because the rebase touches neither the patches nor the interpreter build — same tarball plus byte-identical patches gives the same interpreter.

### One thing worth your call

This adds `3.15.0rc1` to the **default** `RL_CI_VERSIONS`, which makes the standard matrix three versions instead of two. Given you tuned CI for "fast / low cost per build, extended weekly", you may prefer 3.15 to be weekly- or dispatch-only until 3.15.0 final — that's a one-line change to `versions.env` (drop it from `RL_CI_VERSIONS`; it stays pinned and buildable via `--versions=3.15.0rc1`). Happy to flip it either way.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01X3NBRNmNFRuxJTzEiZTTB4
